### PR TITLE
Implement "bors try"; a command to run CI without merging it

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,8 @@ config :aelita2,
 config :aelita2, Aelita2,
   activation_phrase: "bors r+",
   deactivation_phrase: "bors r-",
-  home_url: "https://bors-ng.github.io/"
+  home_url: "https://bors-ng.github.io/",
+  try_phrase: "bors try"
 
 # Configures the endpoint
 config :aelita2, Aelita2.Endpoint,

--- a/lib/aelita2.ex
+++ b/lib/aelita2.ex
@@ -21,6 +21,8 @@ defmodule Aelita2 do
       worker(Application.get_env(:aelita2, Aelita2.GitHub)[:server], []),
       supervisor(Aelita2.Batcher.Supervisor, []),
       worker(Aelita2.Batcher.Registry, []),
+      supervisor(Aelita2.Attemptor.Supervisor, []),
+      worker(Aelita2.Attemptor.Registry, []),
       supervisor(Task.Supervisor, [[name: Aelita2.Syncer.Supervisor]]),
       supervisor(Registry, [:unique, Aelita2.Syncer.Registry]),
     ]

--- a/lib/aelita2/attemptor.ex
+++ b/lib/aelita2/attemptor.ex
@@ -1,0 +1,262 @@
+defmodule Aelita2.Attemptor do
+  @moduledoc """
+  An "Attemptor" manages the set of running attempts (that is, "try jobs").
+  It implements this set of rules:
+
+    * When a patch is tried,
+      We immediately merge it with master into the trying branch.
+    * The project's CI is occasionally polled,
+      if a attempt is currently running.
+      After polling, the completion logic is run.
+    * If a notification related to the underlying CI is received,
+      the completion logic is run.
+    * When the completion logic is run, the either succeeded or failed.
+  """
+
+  use GenServer
+
+  alias Aelita2.Attempt
+  alias Aelita2.AttemptStatus
+  alias Aelita2.Repo
+  alias Aelita2.Patch
+  alias Aelita2.Project
+  alias Aelita2.GitHub
+
+  # Every half-hour
+  @poll_period 30 * 60 * 1000
+
+  # Public API
+
+  def start_link(project_id) do
+    GenServer.start_link(__MODULE__, project_id)
+  end
+
+  def tried(pid, patch_id) when is_integer(patch_id) do
+    GenServer.cast(pid, {:tried, patch_id})
+  end
+
+  def status(pid, stat) do
+    GenServer.cast(pid, {:status, stat})
+  end
+
+  # Server callbacks
+
+  def init(project_id) do
+    Process.send_after(self(), :poll, @poll_period)
+    {:ok, project_id}
+  end
+
+  def handle_cast(args, project_id) do
+    Repo.transaction(fn -> do_handle_cast(args, project_id) end)
+    {:noreply, project_id}
+  end
+
+  def do_handle_cast({:tried, patch_id}, project_id) do
+    patch = Repo.get!(Patch, patch_id)
+    ^project_id = patch.project_id
+    project = Repo.get!(Project, project_id)
+    case Repo.one(Attempt.all_for_patch(patch_id, :incomplete)) do
+      nil ->
+        # There is no currently running attempt
+        # Start one
+        patch_id
+        |> Attempt.new()
+        |> Repo.insert!()
+        |> start_attempt(project, patch)
+      _attempt ->
+        # There is already a running attempt
+        project
+        |> get_repo_conn()
+        |> send_message(patch, :not_awaiting_review)
+    end
+  end
+
+  def do_handle_cast({:status, {commit, identifier, state, url}}, project_id) do
+    attempt = Repo.all(Attempt.get_by_commit(commit, :incomplete))
+    state = AttemptStatus.numberize_state(state)
+    case attempt do
+      [attempt] ->
+        patch = Repo.get!(Patch, attempt.patch_id)
+        ^project_id = patch.project_id
+        project = Repo.get!(Project, project_id)
+        attempt.id
+        |> AttemptStatus.get_for_attempt(identifier)
+        |> Repo.update_all([set: [state: state, url: url]])
+        if attempt.state == Attempt.numberize_state(:running) do
+          maybe_complete_attempt(attempt, project, patch)
+        end
+      [] -> :ok
+    end
+  end
+
+  def handle_info(:poll, project_id) do
+    Repo.transaction(fn -> poll(project_id) end)
+    Process.send_after(self(), :poll, @poll_period)
+    {:noreply, project_id}
+  end
+
+  # Private implementation details
+
+  defp poll(project_id) do
+    project = Repo.get(Project, project_id)
+    project_id
+    |> Attempt.all_for_project(:incomplete)
+    |> Repo.all()
+    |> Enum.filter(&Attempt.next_poll_is_past(&1, project))
+    |> Enum.map(&poll_attempt(&1, project))
+  end
+
+  defp start_attempt(attempt, project, patch) do
+    stmp = "#{project.trying_branch}.tmp"
+    repo_conn = get_repo_conn(project)
+    GitHub.copy_branch!(
+      repo_conn,
+      project.master_branch,
+      stmp)
+    merged = GitHub.merge_branch!(
+      repo_conn,
+      %{
+        from: patch.commit,
+        to: stmp,
+        commit_message: "Try \##{patch.pr_xref}: "})
+    case merged do
+      :conflict ->
+        send_message(repo_conn, patch, {:conflict, :failed})
+        err = Attempt.numberize_state(:error)
+        attempt
+        |> Attempt.changeset(%{state: err})
+        |> Repo.update!()
+      _ ->
+        commit = GitHub.copy_branch!(
+          repo_conn,
+          stmp,
+          project.trying_branch)
+        state = setup_statuses(repo_conn, attempt, project, patch)
+        state = Attempt.numberize_state(state)
+        now = DateTime.to_unix(DateTime.utc_now(), :seconds)
+        attempt
+        |> Attempt.changeset(%{state: state, commit: commit, last_polled: now})
+        |> Repo.update!()
+    end
+  end
+
+  defp setup_statuses(repo_conn, attempt, project, patch) do
+    toml = GitHub.get_file!(
+      repo_conn,
+      project.trying_branch,
+      "bors.toml")
+    case toml do
+      nil ->
+        setup_statuses_error(
+          repo_conn,
+          attempt,
+          patch,
+          :fetch_failed)
+        :error
+      toml ->
+        case Aelita2.Batcher.BorsToml.new(toml) do
+          {:ok, toml} ->
+            toml.status
+            |> Enum.map(&%AttemptStatus{
+                attempt_id: attempt.id,
+                identifier: &1,
+                url: nil,
+                state: AttemptStatus.numberize_state(:running)})
+            |> Enum.each(&Repo.insert!/1)
+            now = DateTime.to_unix(DateTime.utc_now(), :seconds)
+            attempt
+            |> Attempt.changeset(%{timeout_at: now + toml.timeout_sec})
+            |> Repo.update!()
+            :running
+          {:error, message} ->
+            setup_statuses_error(repo_conn,
+              attempt,
+              patch,
+              message)
+            :error
+        end
+    end
+  end
+
+  defp setup_statuses_error(repo_conn, attempt, patch, message) do
+    message = Aelita2.Batcher.Message.generate_bors_toml_error(message)
+    err = Attempt.numberize_state(:error)
+    attempt
+    |> Attempt.changeset(%{state: err})
+    |> Repo.update!()
+    send_message(repo_conn, patch, {:config, message})
+  end
+
+  defp poll_attempt(attempt, project) do
+    patch = Repo.get!(Patch, attempt.patch_id)
+    now = DateTime.to_unix(DateTime.utc_now(), :seconds)
+    if attempt.timeout_at < now do
+      timeout_attempt(attempt, project, patch)
+    else
+      gh_statuses = project
+      |> get_repo_conn()
+      |> GitHub.get_commit_status!(attempt.commit)
+      |> Enum.map(&{elem(&1, 0), AttemptStatus.numberize_state(elem(&1, 1))})
+      |> Map.new()
+      attempt.id
+      |> AttemptStatus.all_for_attempt()
+      |> Repo.all()
+      |> Enum.filter(&Map.has_key?(gh_statuses, &1.identifier))
+      |> Enum.map(&{&1, %{state: Map.fetch!(gh_statuses, &1.identifier)}})
+      |> Enum.map(&AttemptStatus.changeset(elem(&1, 0), elem(&1, 1)))
+      |> Enum.each(&Repo.update!/1)
+      maybe_complete_attempt(attempt, project, patch)
+    end
+  end
+
+  defp maybe_complete_attempt(attempt, project, patch) do
+    statuses = Repo.all(AttemptStatus.all_for_attempt(attempt.id))
+    state = Aelita2.Batcher.State.summary_statuses(statuses)
+    maybe_complete_attempt(state, project, patch, statuses)
+    state = Attempt.numberize_state(state)
+    now = DateTime.to_unix(DateTime.utc_now(), :seconds)
+    attempt
+    |> Attempt.changeset(%{state: state, last_polled: now})
+    |> Repo.update!()
+  end
+
+  defp maybe_complete_attempt(:ok, project, patch, statuses) do
+    repo_conn = get_repo_conn(project)
+    send_message(repo_conn, patch, {:succeeded, statuses})
+  end
+
+  defp maybe_complete_attempt(:error, project, patch, statuses) do
+    repo_conn = get_repo_conn(project)
+    erred = Enum.filter(
+      statuses,
+      &(&1.state == AttemptStatus.numberize_state(:error)))
+    send_message(repo_conn, patch, {:failed, erred})
+  end
+
+  defp maybe_complete_attempt(:running, _project, _patch, _statuses) do
+    :ok
+  end
+
+  defp timeout_attempt(attempt, project, patch) do
+    project
+    |> get_repo_conn()
+    |> send_message(patch, {:timeout, :failed})
+    err = Attempt.numberize_state(:error)
+    attempt
+    |> Attempt.changeset(%{state: err})
+    |> Repo.update!()
+  end
+
+  defp send_message(repo_conn, patch, message) do
+    body = Aelita2.Batcher.Message.generate_message(message)
+    GitHub.post_comment!(
+      repo_conn,
+      patch.pr_xref,
+      body)
+  end
+
+  @spec get_repo_conn(%Project{}) :: {{:installation, number}, number}
+  defp get_repo_conn(project) do
+    Project.installation_connection(project.repo_xref, Repo)
+  end
+end

--- a/lib/aelita2/attemptor/command.ex
+++ b/lib/aelita2/attemptor/command.ex
@@ -1,0 +1,30 @@
+defmodule Aelita2.Attemptor.Command do
+  @moduledoc """
+  The bors comment CLI allows parameters to be passed to try.
+  Assuming the activation phrase is "bors try", you can do things like this:
+
+      bors try --layout
+
+  And the commit will come out like:
+
+      Try #13: --layout
+
+  Your build scripts should then inspect the commit message
+  to pull out the commands.
+  """
+
+  @try_phrase Application.get_env(:aelita2, Aelita2)[:try_phrase]
+
+  @spec parse(binary) :: binary | :nomatch
+  def parse(@try_phrase <> arguments) do
+    arguments
+  end
+
+  def parse(<<_, rest :: binary>>) do
+    parse(rest)
+  end
+
+  def parse(<<>>) do
+    :nomatch
+  end
+end

--- a/lib/aelita2/attemptor/registry.ex
+++ b/lib/aelita2/attemptor/registry.ex
@@ -1,0 +1,72 @@
+defmodule Aelita2.Attemptor.Registry do
+  @moduledoc """
+  The "Attemptor" manages the project's try branch.
+  This is the registry of each individual attemptor.
+  It starts the attemptor if it doesn't exist,
+  restarts it if it crashes,
+  and logs the crashes because that's needed sometimes.
+
+  Note that the attemptor and registry are always on the same node.
+  Sharding between them will be done by directing which registry to go to.
+  """
+
+  use GenServer
+
+  alias Aelita2.Attemptor
+  alias Aelita2.Project
+  alias Aelita2.Repo
+
+  @name Aelita2.Attemptor.Registry
+
+  # Public API
+
+  def start_link do
+    GenServer.start_link(__MODULE__, :ok, name: @name)
+  end
+
+  def get(project_id) when is_integer(project_id) do
+    GenServer.call(@name, {:get, project_id})
+  end
+
+  # Server callbacks
+
+  def init(:ok) do
+    names = Project
+    |> Repo.all()
+    |> Enum.map(&{&1.id, do_start(&1.id)})
+    |> Map.new()
+    refs = names
+    |> Enum.map(&{Process.monitor(elem(&1, 1)), elem(&1, 0)})
+    |> Map.new()
+    {:ok, {names, refs}}
+  end
+
+  def do_start(project_id) do
+    {:ok, pid} = Attemptor.Supervisor.start(project_id)
+    pid
+  end
+
+  def handle_call({:get, project_id}, _from, {names, refs}) do
+    {pid, names, refs} = case names[project_id] do
+      nil ->
+        pid = do_start(project_id)
+        names = Map.put(names, project_id, pid)
+        ref = Process.monitor(pid)
+        refs = Map.put(names, ref, project_id)
+        {pid, names, refs}
+      pid ->
+        {pid, names, refs}
+    end
+    {:reply, pid, {names, refs}}
+  end
+
+  def handle_info({:DOWN, ref, :process, _pid, _reason}, {names, refs}) do
+    {project_id, refs} = Map.pop(refs, ref)
+    names = Map.delete(names, project_id)
+    {:noreply, {names, refs}}
+  end
+
+  def handle_info(_msg, state) do
+    {:noreply, state}
+  end
+end

--- a/lib/aelita2/attemptor/supervisor.ex
+++ b/lib/aelita2/attemptor/supervisor.ex
@@ -1,0 +1,24 @@
+defmodule Aelita2.Attemptor.Supervisor do
+  @moduledoc """
+  The supervisor of all of the batchers.
+  """
+  use Supervisor
+
+  @name Aelita2.Attemptor.Supervisor
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, :ok, name: @name)
+  end
+
+  def start(project_id) do
+    Supervisor.start_child(@name, [project_id])
+  end
+
+  def init(:ok) do
+    children = [
+      worker(Aelita2.Attemptor, [], restart: :temporary)
+    ]
+
+    supervise(children, strategy: :simple_one_for_one)
+  end
+end

--- a/lib/aelita2/github.ex
+++ b/lib/aelita2/github.ex
@@ -53,7 +53,7 @@ defmodule Aelita2.GitHub do
     from: bitstring,
     to: bitstring,
     commit_message: bitstring,
-    }) :: %{commit: bitstring, tree: binary}
+    }) :: %{commit: bitstring, tree: binary} | :conflict
   def merge_branch!(repo_conn, info) do
     {:ok, commit} = GenServer.call(
       Aelita2.GitHub,

--- a/lib/aelita2/models/attempt.ex
+++ b/lib/aelita2/models/attempt.ex
@@ -1,0 +1,117 @@
+defmodule Aelita2.Attempt do
+  @moduledoc """
+  The database-level representation of a "attempt".
+
+  When a patch is tried, it gets merged with master individually
+  and it's CI result is reported, but it is not pushed to master.
+  """
+
+  use Aelita2.Web, :model
+
+  alias Aelita2.Attempt
+  alias Aelita2.Patch
+
+  schema "attempts" do
+    belongs_to :patch, Aelita2.Patch
+    field :commit, :string
+    field :state, :integer
+    field :last_polled, :integer
+    field :timeout_at, :integer
+    timestamps()
+  end
+
+  def new(patch_id) do
+    %Attempt{
+      patch_id: patch_id,
+      commit: nil,
+      state: 0,
+      last_polled: DateTime.to_unix(DateTime.utc_now(), :seconds)
+    }
+  end
+
+  def atomize_state(state) do
+    case state do
+      0 -> :waiting
+      1 -> :running
+      2 -> :ok
+      3 -> :error
+      4 -> :canceled
+    end
+  end
+
+  def numberize_state(st) do
+    case st do
+      :waiting -> 0
+      :running -> 1
+      :ok -> 2
+      :error -> 3
+      :canceled -> 4
+    end
+  end
+
+  def all(:incomplete) do
+    from b in Attempt,
+      where: b.state == 0 or b.state == 1
+  end
+
+  def all_for_project(project_id, state) do
+    from b in all(state),
+      join: p in Patch, on: p.id == b.patch_id,
+      where: p.project_id == ^project_id
+  end
+
+  def all_for_patch(patch_id) do
+    from b in Attempt,
+      where: b.patch_id == ^patch_id
+  end
+
+  def all_for_patch(patch_id, nil), do: all_for_patch(patch_id)
+
+  def all_for_patch(patch_id, :incomplete) do
+    from b in all_for_patch(patch_id),
+      where: b.state == 0 or b.state == 1
+  end
+
+  def all_for_patch(patch_id, :complete) do
+    from b in all_for_patch(patch_id),
+      where: b.state == 2 or b.state == 3 or b.state == 4
+  end
+
+  def all_for_patch(patch_id, state) do
+    state = Attempt.numberize_state(state)
+    from b in all_for_patch(patch_id),
+      where: b.state == ^state
+  end
+
+  def get_by_commit(commit, state) do
+    from b in all(state),
+      where: b.commit == ^commit
+  end
+
+  def next_poll_is_past(attempt, project) do
+    now = DateTime.to_unix(DateTime.utc_now(), :seconds)
+    next_poll_is_past(attempt, project, now)
+  end
+
+  def next_poll_is_past(attempt, project, now_utc_sec) do
+    next = get_next_poll_unix_sec(attempt, project)
+    next < now_utc_sec
+  end
+
+  def timeout_is_past(%Attempt{timeout_at: timeout_at}) do
+    now = DateTime.to_unix(DateTime.utc_now(), :seconds)
+    now > timeout_at
+  end
+
+  def get_next_poll_unix_sec(attempt, project) do
+    attempt.last_polled + project.batch_poll_period_sec
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:patch_id, :commit, :state, :last_polled, :timeout_at])
+  end
+end

--- a/lib/aelita2/models/attempt_status.ex
+++ b/lib/aelita2/models/attempt_status.ex
@@ -1,0 +1,68 @@
+defmodule Aelita2.AttemptStatus do
+  @moduledoc """
+  A database record for an individual CI run.
+  It corresponds to an item in the status = []
+  array of bors.toml.
+
+  This version links to an attempt,
+  rather than a batch.
+  """
+
+  use Aelita2.Web, :model
+
+  alias Aelita2.AttemptStatus
+
+  schema "attempt_statuses" do
+    belongs_to :attempt, Aelita2.Attempt
+    field :identifier, :string
+    field :url, :string
+    field :state, :integer
+    timestamps()
+  end
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:attempt_id, :identifier, :url, :state])
+  end
+
+  def get_for_attempt(attempt_id, identifier) do
+    from s in AttemptStatus,
+      where: s.attempt_id == ^attempt_id,
+      where: s.identifier == ^identifier
+  end
+
+  def all_for_attempt(attempt_id) do
+    from s in AttemptStatus, where: s.attempt_id == ^attempt_id
+  end
+
+  def all_for_attempt(attempt_id, :incomplete) do
+    from s in AttemptStatus,
+      where: s.attempt_id == ^attempt_id,
+      where: s.state == 1 or s.state == 0
+  end
+
+  def all_for_attempt(attempt_id, state) do
+    state = AttemptStatus.numberize_state(state)
+    from s in AttemptStatus,
+      where: s.attempt_id == ^attempt_id,
+      where: s.state == ^state
+  end
+
+  def atomize_state(state) do
+    case state do
+      0 -> :waiting
+      1 -> :running
+      2 -> :ok
+      3 -> :error
+    end
+  end
+
+  def numberize_state(state) do
+    case state do
+      :waiting -> 0
+      :running -> 1
+      :ok -> 2
+      :error -> 3
+    end
+  end
+end

--- a/lib/aelita2/models/project.ex
+++ b/lib/aelita2/models/project.ex
@@ -19,6 +19,7 @@ defmodule Aelita2.Project do
     many_to_many :users, User, join_through: LinkUserProject
     field :master_branch, :string, default: "master"
     field :staging_branch, :string, default: "staging"
+    field :trying_branch, :string, default: "trying"
     field :batch_poll_period_sec, :integer, default: (60 * 30)
     field :batch_delay_sec, :integer, default: 10
     field :batch_timeout_sec, :integer, default: (60 * 60 * 2)
@@ -63,8 +64,8 @@ defmodule Aelita2.Project do
   end
   def changeset_branches(struct, params \\ %{}) do
     struct
-    |> cast(params, [:master_branch, :staging_branch])
-    |> validate_required([:master_branch, :staging_branch])
+    |> cast(params, [:master_branch, :staging_branch, :trying_branch])
+    |> validate_required([:master_branch, :staging_branch, :trying_branch])
   end
 
   # Red flag queries

--- a/priv/repo/migrations/20170202012909_try.exs
+++ b/priv/repo/migrations/20170202012909_try.exs
@@ -1,0 +1,24 @@
+defmodule Aelita2.Repo.Migrations.Try do
+  use Ecto.Migration
+
+  def change do
+    create table(:attempts) do
+      add :patch_id, references(:patches, on_delete: :delete_all)
+      add :commit, :string
+      add :state, :integer
+      add :last_polled, :integer
+      add :timeout_at, :integer
+      timestamps()
+    end
+    create table(:attempt_statuses) do
+      add :attempt_id, references(:attempts, on_delete: :delete_all)
+      add :identifier, :string
+      add :url, :string
+      add :state, :integer
+      timestamps()
+    end
+    alter table(:projects) do
+      add :trying_branch, :string, default: "trying"
+    end
+  end
+end

--- a/test/attemptor_command_test.exs
+++ b/test/attemptor_command_test.exs
@@ -1,0 +1,33 @@
+defmodule Aelita2.AttemptorCommandTest do
+  use Aelita2.ModelCase, async: true
+
+  alias Aelita2.Attemptor.Command
+
+  test "reject the empty string" do
+    assert :nomatch == Command.parse("")
+  end
+
+  test "reject strings without the phrase" do
+    assert :nomatch == Command.parse("doink!")
+  end
+
+  test "reject a string that merely starts out like a command" do
+    assert :nomatch == Command.parse("bors doink")
+  end
+
+  test "accept the bare command" do
+    assert "" == Command.parse("bors try")
+  end
+
+  test "accept the command with an argument" do
+    assert "-layout" == Command.parse("bors try-layout")
+  end
+
+  test "accept the command with more argumentation" do
+    assert " --layout --script" == Command.parse("bors try --layout --script")
+  end
+
+  test "accept the command with a prefix" do
+    assert "Z" == Command.parse("Xbors tryZ")
+  end
+end

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -1,0 +1,132 @@
+defmodule Aelita2.AttemptorTest do
+  use Aelita2.ModelCase
+
+  alias Aelita2.Attempt
+  alias Aelita2.Attemptor
+  alias Aelita2.GitHub
+  alias Aelita2.Installation
+  alias Aelita2.Patch
+  alias Aelita2.Project
+
+  setup do
+    inst = %Installation{installation_xref: 91}
+    |> Repo.insert!()
+    proj = %Project{
+      installation_id: inst.id,
+      repo_xref: 14,
+      master_branch: "master",
+      staging_branch: "staging",
+      trying_branch: "trying"}
+    |> Repo.insert!()
+    {:ok, inst: inst, proj: proj}
+  end
+
+  test "rejects running patches", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        comments: %{1 => []},
+        statuses: %{},
+        files: %{}
+      }})
+    patch = %Patch{project_id: proj.id, pr_xref: 1} |> Repo.insert!()
+    _attempt = %Attempt{patch_id: patch.id, state: 0, patch_id: patch.id}
+    |> Repo.insert!()
+    Attemptor.handle_cast({:tried, patch.id}, proj.id)
+    state = GitHub.ServerMock.get_state()
+    assert state == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        comments: %{
+          1 => [ "Not awaiting review" ]
+          },
+        statuses: %{},
+        files: %{}
+      }}
+  end
+
+  test "full runthrough (with polling fallback)", %{proj: proj} do
+    # Attempts start running immediately
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{ "master" => "ini", "trying" => "", "trying.tmp" => "" },
+        comments: %{ 1 => [] },
+        statuses: %{ "iniN" => [] },
+        files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
+      }})
+    patch = %Patch{
+      project_id: proj.id,
+      pr_xref: 1,
+      commit: "N"}
+    |> Repo.insert!()
+    Attemptor.handle_cast({:tried, patch.id}, proj.id)
+    assert GitHub.ServerMock.get_state() == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{
+          "master" => "ini",
+          "trying" => "iniN",
+          "trying.tmp" => "iniN" },
+        comments: %{ 1 => [] },
+        statuses: %{ "iniN" => [] },
+        files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
+      }}
+    attempt = Repo.get_by! Attempt, patch_id: patch.id
+    assert attempt.state == 1
+    # Polling should not change that.
+    Attemptor.handle_info(:poll, proj.id)
+    assert GitHub.ServerMock.get_state() == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{
+          "master" => "ini",
+          "trying" => "iniN",
+          "trying.tmp" => "iniN" },
+        comments: %{ 1 => [] },
+        statuses: %{ "iniN" => [] },
+        files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
+      }}
+    attempt = Repo.get_by! Attempt, patch_id: patch.id
+    assert attempt.state == 1
+    # Mark the CI as having finished.
+    # At this point, just running should still do nothing.
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{
+          "master" => "ini",
+          "trying" => "iniN",
+          "trying.tmp" => "iniN" },
+        comments: %{ 1 => [] },
+        statuses: %{ "iniN" => [ {"ci", :ok}] },
+        files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
+      }})
+    Attemptor.handle_info(:poll, proj.id)
+    attempt = Repo.get_by! Attempt, patch_id: patch.id
+    assert attempt.state == 1
+    assert GitHub.ServerMock.get_state() == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{
+          "master" => "ini",
+          "trying" => "iniN",
+          "trying.tmp" => "iniN" },
+        comments: %{ 1 => [] },
+        statuses: %{ "iniN" => [ {"ci", :ok}] },
+        files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
+      }}
+    # Finally, an actual poll should finish it.
+    attempt
+    |> Attempt.changeset(%{last_polled: 0})
+    |> Repo.update!()
+    Attemptor.handle_info(:poll, proj.id)
+    attempt = Repo.get_by! Attempt, patch_id: patch.id
+    assert attempt.state == 2
+    assert GitHub.ServerMock.get_state() == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{
+          "master" => "ini",
+          "trying" => "iniN",
+          "trying.tmp" => "iniN" },
+        comments: %{ 1 => [ "# Build succeeded\n  * ci" ] },
+        statuses: %{ "iniN" => [ {"ci", :ok}] },
+        files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
+      }}
+  end
+end

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -32,7 +32,7 @@ defmodule Aelita2.AttemptorTest do
     patch = %Patch{project_id: proj.id, pr_xref: 1} |> Repo.insert!()
     _attempt = %Attempt{patch_id: patch.id, state: 0, patch_id: patch.id}
     |> Repo.insert!()
-    Attemptor.handle_cast({:tried, patch.id}, proj.id)
+    Attemptor.handle_cast({:tried, patch.id, ""}, proj.id)
     state = GitHub.ServerMock.get_state()
     assert state == %{
       {{:installation, 91}, 14} => %{
@@ -59,7 +59,7 @@ defmodule Aelita2.AttemptorTest do
       pr_xref: 1,
       commit: "N"}
     |> Repo.insert!()
-    Attemptor.handle_cast({:tried, patch.id}, proj.id)
+    Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{

--- a/web/controllers/webhook_controller.ex
+++ b/web/controllers/webhook_controller.ex
@@ -132,6 +132,12 @@ defmodule Aelita2.WebhookController do
   end
 
   def do_webhook(conn, "github", "status") do
+    do_webhook_status(
+      conn,
+      conn.body_params["commit"]["commit"]["message"])
+  end
+
+  def do_webhook_status(conn, "Merge " <> _) do
     identifier = conn.body_params["context"]
     commit = conn.body_params["sha"]
     url = conn.body_params["target_url"]
@@ -140,17 +146,33 @@ defmodule Aelita2.WebhookController do
     project = Repo.get_by(Project, repo_xref: repo_xref)
     batcher = Batcher.Registry.get(project.id)
     Batcher.status(batcher, {commit, identifier, state, url})
+  end
 
-    commit_msg = conn.body_params["commit"]["commit"]["message"]
+  def do_webhook_status(conn, "Try " <> _) do
+    identifier = conn.body_params["context"]
+    commit = conn.body_params["sha"]
+    url = conn.body_params["target_url"]
+    repo_xref = conn.body_params["repository"]["id"]
+    state = GitHub.map_state_to_status(conn.body_params["state"])
+    project = Repo.get_by(Project, repo_xref: repo_xref)
+    attemptor = Attemptor.Registry.get(project.id)
+    Attemptor.status(attemptor, {commit, identifier, state, url})
+  end
+
+  def do_webhook_status(conn, "-bors-staging-tmp-" <> pr_xref) do
+    identifier = conn.body_params["context"]
     err_msg = Batcher.Message.generate_staging_tmp_message(identifier)
-    case {commit_msg, err_msg} do
-      {_, nil} -> :ok
-      {"-bors-staging-tmp-" <> pr_xref, err_msg} ->
+    case err_msg do
+      nil -> :ok
+      err_msg ->
         conn.body_params["repository"]["id"]
         |> Project.installation_connection(Repo)
         |> GitHub.post_comment!(String.to_integer(pr_xref), err_msg)
-      _ -> :ok
     end
+  end
+
+  def do_webhook_status(_conn, _) do
+    :ok
   end
 
   def do_webhook_pr(_conn, %{action: "opened", project: project}) do

--- a/web/controllers/webhook_controller.ex
+++ b/web/controllers/webhook_controller.ex
@@ -232,7 +232,7 @@ defmodule Aelita2.WebhookController do
     config = Application.get_env(:aelita2, Aelita2)
     activated = :binary.match(comment, config[:activation_phrase])
     deactivated = :binary.match(comment, config[:deactivation_phrase])
-    tried = :binary.match(comment, config[:try_phrase])
+    tried = Attemptor.Command.parse(comment)
     cur_branch = pr.base_ref == project.master_branch
     case {activated, deactivated, tried} do
       {:nomatch, :nomatch, :nomatch} -> :ok
@@ -253,9 +253,9 @@ defmodule Aelita2.WebhookController do
           {:nomatch, _deactivated, :nomatch, _} ->
             batcher = Batcher.Registry.get(project.id)
             Batcher.cancel(batcher, p.id)
-          {:nomatch, :nomatch, _tried, _} ->
+          {:nomatch, :nomatch, arguments, _} ->
             attemptor = Attemptor.Registry.get(project.id)
-            Attemptor.tried(attemptor, p.id)
+            Attemptor.tried(attemptor, p.id, arguments)
           {_, _, _, _} ->
             project.repo_xref
             |> Project.installation_connection(Repo)

--- a/web/controllers/webhook_controller.ex
+++ b/web/controllers/webhook_controller.ex
@@ -234,6 +234,12 @@ defmodule Aelita2.WebhookController do
           {:nomatch, :nomatch, _tried, _} ->
             attemptor = Attemptor.Registry.get(project.id)
             Attemptor.tried(attemptor, p.id)
+          {_, _, _, _} ->
+            project.repo_xref
+            |> Project.installation_connection(Repo)
+            |> GitHub.post_comment!(
+              p.pr_xref,
+              ":confused: Multiple matching commands")
         end
     end
   end

--- a/web/templates/project/settings.html.eex
+++ b/web/templates/project/settings.html.eex
@@ -69,6 +69,8 @@
   <%= text_input f, :master_branch, id: "master_branch" %>
   <label for=staging_branch>staging</label>
   <%= text_input f, :staging_branch, id: "staging_branch" %>
+  <label for=trying_branch>trying</label>
+  <%= text_input f, :trying_branch, id: "trying_branch" %>
   <div class=toolbar><%= submit "Update", class: "toolbar-item" %></div>
 <% end %>
 


### PR DESCRIPTION
This is merging it with master, but the result goes in a "trying" branch, and master isn't fast-forwarded to do it.

This is contains a bit much copy-and-paste coding, which will be fixed by pulling commonalities out into their own code and processes (some of this is already there, with the common message and state machine templates, but more is needed).

Fixes #26 