### PR TITLE
Clean up staging.tmp handling

### DIFF
--- a/lib/aelita2/attemptor.ex
+++ b/lib/aelita2/attemptor.ex
@@ -159,6 +159,7 @@ defmodule Aelita2.Attemptor do
         |> Attempt.changeset(%{state: state, commit: commit, last_polled: now})
         |> Repo.update!()
     end
+    GitHub.delete_branch!(repo_conn, stmp)
   end
 
   defp setup_statuses(repo_conn, attempt, project, patch) do

--- a/lib/aelita2/batcher.ex
+++ b/lib/aelita2/batcher.ex
@@ -197,10 +197,17 @@ defmodule Aelita2.Batcher do
     project = batch.project
     stmp = "#{project.staging_branch}.tmp"
     repo_conn = get_repo_conn(project)
-    base = GitHub.copy_branch!(
+    base = GitHub.get_branch!(
       repo_conn,
-      project.master_branch,
-      stmp)
+      project.master_branch)
+    tbase = GitHub.synthesize_commit!(
+      repo_conn,
+      %{
+        branch: stmp,
+        tree: base.tree,
+        parents: [base.commit],
+        commit_message: "[ci skip]"
+        })
     do_merge_patch = fn patch, branch ->
       case branch do
         :conflict -> :conflict
@@ -209,13 +216,13 @@ defmodule Aelita2.Batcher do
           %{
             from: patch.commit,
             to: stmp,
-            commit_message: "-bors-staging-tmp-#{patch.pr_xref}"
+            commit_message: "[ci skip] -bors-staging-tmp-#{patch.pr_xref}"
           })
       end
     end
     head = with(
-      %{tree: tree} <- Enum.reduce(patches, base, do_merge_patch),
-      parents <- [base | Enum.map(patches, &(&1.commit))],
+      %{tree: tree} <- Enum.reduce(patches, tbase, do_merge_patch),
+      parents <- [base.commit | Enum.map(patches, &(&1.commit))],
       commit_message <- Batcher.Message.generate_commit_message(patches),
       do: GitHub.synthesize_commit!(
         repo_conn,

--- a/lib/aelita2/batcher.ex
+++ b/lib/aelita2/batcher.ex
@@ -231,6 +231,7 @@ defmodule Aelita2.Batcher do
           tree: tree,
           parents: parents,
           commit_message: commit_message}))
+    GitHub.delete_branch!(repo_conn, stmp)
     case head do
       :conflict ->
         state = bisect(patches, project)

--- a/lib/aelita2/github.ex
+++ b/lib/aelita2/github.ex
@@ -50,6 +50,14 @@ defmodule Aelita2.GitHub do
     commit
   end
 
+  @spec delete_branch!(tconn, binary) :: :ok
+  def delete_branch!(repo_conn, branch) do
+    :ok = GenServer.call(
+      Aelita2.GitHub,
+      {:delete_branch, repo_conn, {branch}})
+    :ok
+  end
+
   @spec merge_branch!(tconn, %{
     from: bitstring,
     to: bitstring,

--- a/lib/aelita2/github.ex
+++ b/lib/aelita2/github.ex
@@ -42,12 +42,12 @@ defmodule Aelita2.GitHub do
     sha
   end
 
-  @spec copy_branch!(tconn, binary, binary) :: binary
-  def copy_branch!(repo_conn, from, to) do
-    {:ok, sha} = GenServer.call(
+  @spec get_branch!(tconn, binary) :: %{commit: bitstring, tree: bitstring}
+  def get_branch!(repo_conn, from) do
+    {:ok, commit} = GenServer.call(
       Aelita2.GitHub,
-      {:copy_branch, repo_conn, {from, to}})
-    sha
+      {:get_branch, repo_conn, {from}})
+    commit
   end
 
   @spec merge_branch!(tconn, %{

--- a/lib/aelita2/github/server.ex
+++ b/lib/aelita2/github/server.ex
@@ -77,13 +77,13 @@ defmodule Aelita2.GitHub.Server do
     end
   end
 
-  def do_handle_call(:copy_branch, repo_conn, {from, to}) do
-    case get!(repo_conn, "branches/#{from}") do
+  def do_handle_call(:get_branch, repo_conn, {branch}) do
+    case get!(repo_conn, "branches/#{branch}") do
       %{body: raw, status_code: 200} ->
-        sha = Poison.decode!(raw)["commit"]["sha"]
-        do_handle_call(:force_push, repo_conn, {sha, to})
+        r = Poison.decode!(raw)["commit"]
+        {:ok, %{commit: r["sha"], tree: r["commit"]["tree"]["sha"]}}
       _ ->
-        {:error, :copy_branch}
+        {:error, :get_branch}
     end
   end
 

--- a/lib/aelita2/github/server.ex
+++ b/lib/aelita2/github/server.ex
@@ -87,6 +87,15 @@ defmodule Aelita2.GitHub.Server do
     end
   end
 
+  def do_handle_call(:delete_branch, repo_conn, {branch}) do
+    case delete!(repo_conn, "git/refs/heads/#{branch}") do
+      %{status_code: 204} ->
+        :ok
+      _ ->
+        {:error, :delete_branch}
+    end
+  end
+
   def do_handle_call(:merge_branch, repo_conn, {%{
     from: from,
     to: to,
@@ -321,6 +330,19 @@ defmodule Aelita2.GitHub.Server do
     params \\ []
     ) do
     HTTPoison.get!(
+      "#{config()[:site]}/repositories/#{repo_xref}/#{path}",
+      [{"Authorization", "token #{token}"}] ++ headers,
+      params)
+  end
+
+  @spec delete!(tconn, binary, list, list) :: map
+  defp delete!(
+    {{:raw, token}, repo_xref},
+    path,
+    headers \\ [],
+    params \\ []
+    ) do
+    HTTPoison.delete!(
       "#{config()[:site]}/repositories/#{repo_xref}/#{path}",
       [{"Authorization", "token #{token}"}] ++ headers,
       params)

--- a/lib/aelita2/github/server_mock.ex
+++ b/lib/aelita2/github/server_mock.ex
@@ -171,21 +171,18 @@ defmodule Aelita2.GitHub.ServerMock do
     end
   end
 
-  def do_handle_call(:copy_branch, repo_conn, {from, to}, state) do
+  def do_handle_call(:get_branch, repo_conn, {from}, state) do
     with {:ok, repo} <- Map.fetch(state, repo_conn),
          {:ok, branches} <- Map.fetch(repo, :branches) do
       sha = case branches[from] do
         nil -> from
         sha -> sha
       end
-      branches = %{ branches | to => sha }
-      repo = %{ repo | branches: branches }
-      state = %{ state | repo_conn => repo }
-      {{:ok, sha}, state}
+      {{:ok, %{commit: sha, tree: sha}}, state}
     end
     |> case do
       {{:ok, _}, _} = res -> res
-      _ -> {{:error, :copy_branch}, state}
+      _ -> {{:error, :get_branch}, state}
     end
   end
 

--- a/lib/aelita2/github/server_mock.ex
+++ b/lib/aelita2/github/server_mock.ex
@@ -186,6 +186,20 @@ defmodule Aelita2.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:delete_branch, repo_conn, {branch}, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn),
+         {:ok, branches} <- Map.fetch(repo, :branches) do
+      branches = Map.delete(branches, branch)
+      repo = %{ repo | branches: branches }
+      state = %{ state | repo_conn => repo }
+      {:ok, state}
+    end
+    |> case do
+      {:ok, _} = res -> res
+      _ -> {{:error, :get_branch}, state}
+    end
+  end
+
   def do_handle_call(:merge_branch, repo_conn, {%{
     from: from,
     to: to,

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -103,8 +103,7 @@ defmodule Aelita2.AttemptorTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "trying" => "iniN",
-          "trying.tmp" => "iniN" },
+          "trying" => "iniN" },
         comments: %{ 1 => [] },
         statuses: %{ "iniN" => [] },
         files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
@@ -117,8 +116,7 @@ defmodule Aelita2.AttemptorTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "trying" => "iniN",
-          "trying.tmp" => "iniN" },
+          "trying" => "iniN" },
         comments: %{ 1 => [] },
         statuses: %{ "iniN" => [] },
         files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
@@ -131,8 +129,7 @@ defmodule Aelita2.AttemptorTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "trying" => "iniN",
-          "trying.tmp" => "iniN" },
+          "trying" => "iniN" },
         comments: %{ 1 => [] },
         statuses: %{ "iniN" => [ {"ci", :ok}] },
         files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
@@ -144,8 +141,7 @@ defmodule Aelita2.AttemptorTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "trying" => "iniN",
-          "trying.tmp" => "iniN" },
+          "trying" => "iniN" },
         comments: %{ 1 => [] },
         statuses: %{ "iniN" => [ {"ci", :ok}] },
         files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
@@ -161,8 +157,7 @@ defmodule Aelita2.AttemptorTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "trying" => "iniN",
-          "trying.tmp" => "iniN" },
+          "trying" => "iniN" },
         comments: %{ 1 => [ "# Build succeeded\n  * ci" ] },
         statuses: %{ "iniN" => [ {"ci", :ok}] },
         files: %{ "trying" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -164,8 +164,7 @@ defmodule Aelita2.BatcherTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "staging" => "iniN",
-          "staging.tmp" => "iniN" },
+          "staging" => "iniN" },
         comments: %{ 1 => [ "# Configuration problem\nbors.toml: not found" ] },
         statuses: %{ "N" => %{ "bors" => :error } },
         files: %{}
@@ -212,8 +211,7 @@ defmodule Aelita2.BatcherTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "staging" => "iniN",
-          "staging.tmp" => "iniN" },
+          "staging" => "iniN" },
         comments: %{ 1 => [] },
         statuses: %{ "iniN" => %{}, "N" => %{ "bors" => :running } },
         files: %{ "staging" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
@@ -233,8 +231,7 @@ defmodule Aelita2.BatcherTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "staging" => "iniN",
-          "staging.tmp" => "iniN" },
+          "staging" => "iniN" },
         comments: %{ 1 => [] },
         statuses: %{ "iniN" => %{}, "N" => %{ "bors" => :running } },
         files: %{ "staging" => %{ "bors.toml" => ~s/status = [ "ci" ]/ } }
@@ -245,8 +242,7 @@ defmodule Aelita2.BatcherTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "staging" => "iniN",
-          "staging.tmp" => "iniN" },
+          "staging" => "iniN" },
         comments: %{ 1 => [] },
         statuses: %{
           "iniN" => %{ "ci" => :ok },
@@ -260,8 +256,7 @@ defmodule Aelita2.BatcherTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "ini",
-          "staging" => "iniN",
-          "staging.tmp" => "iniN" },
+          "staging" => "iniN" },
         comments: %{ 1 => [] },
         statuses: %{
           "iniN" => %{ "ci" => :ok },
@@ -279,8 +274,7 @@ defmodule Aelita2.BatcherTest do
       {{:installation, 91}, 14} => %{
         branches: %{
           "master" => "iniN",
-          "staging" => "iniN",
-          "staging.tmp" => "iniN" },
+          "staging" => "iniN" },
         comments: %{ 1 => [ "# Build succeeded\n  * ci" ] },
         statuses: %{
           "iniN" => %{ "bors" => :ok, "ci" => :ok },

--- a/web/controllers/webhook_controller.ex
+++ b/web/controllers/webhook_controller.ex
@@ -159,7 +159,7 @@ defmodule Aelita2.WebhookController do
     Attemptor.status(attemptor, {commit, identifier, state, url})
   end
 
-  def do_webhook_status(conn, "-bors-staging-tmp-" <> pr_xref) do
+  def do_webhook_status(conn, "[ci skip] -bors-staging-tmp-" <> pr_xref) do
     identifier = conn.body_params["context"]
     err_msg = Batcher.Message.generate_staging_tmp_message(identifier)
     case err_msg do


### PR DESCRIPTION
* Put "(ci skip)" in the commit messages
* Instead of copying master to staging.tmp, create an empty commit with "(ci skip)" at that branch (to ensure that staging.tmp is not built because of that commit).
* Delete staging.tmp after starting the build, so that it won't show up in repository viewers (it's just noise)