### PR TITLE
Add a shortcut to the GitHub integration page from the repos page.

### DIFF
--- a/apps/bors_frontend/config/config.exs
+++ b/apps/bors_frontend/config/config.exs
@@ -13,7 +13,9 @@ config :bors_frontend, BorsNG,
   activation_by_phrase: "bors r=",
   deactivation_phrase: "bors r-",
   home_url: "https://bors-ng.github.io/",
-  try_phrase: "bors try"
+  try_phrase: "bors try",
+  github_integration_url:
+    "https://github.com/integrations/bors/installations/new"
 
 # Configures the endpoint
 config :bors_frontend, BorsNG.Endpoint,

--- a/apps/bors_frontend/web/templates/project/index.html.eex
+++ b/apps/bors_frontend/web/templates/project/index.html.eex
@@ -16,6 +16,12 @@
 </div>
 <% end %>
 
+<div class=toolbar>
+  <a class=toolbar-item href="<%= Application.get_env(:bors_frontend, BorsNG)[:github_integration_url] %>">
+    Add / Remove Repositories
+  </a>
+</div>
+
 <table class="table">
   <tbody>
 <%= for project <- @projects do %>


### PR DESCRIPTION
Fixes https://github.com/bors-ng/bors-ng/issues/93.