### PR TITLE
Reject private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Or you can do it manually:
         MIX_ENV=prod \
         POOL_SIZE=18 \
         PUBLIC_HOST=bors-app.herokuapp.com \
+        ALLOW_PRIVATE_REPOS=true \
         SECRET_KEY_BASE=<SECRET1> \
         GITHUB_CLIENT_ID=<OAUTH_CLIENT_ID> \
         GITHUB_CLIENT_SECRET=<OAUTH_CLIENT_SECRET> \

--- a/apps/bors_frontend/config/config.exs
+++ b/apps/bors_frontend/config/config.exs
@@ -15,7 +15,8 @@ config :bors_frontend, BorsNG,
   home_url: "https://bors-ng.github.io/",
   try_phrase: "bors try",
   github_integration_url:
-    "https://github.com/integrations/bors/installations/new"
+    "https://github.com/integrations/bors/installations/new",
+  allow_private_repos: System.get_env("ALLOW_PRIVATE_REPOS") == "true"
 
 # Configures the endpoint
 config :bors_frontend, BorsNG.Endpoint,

--- a/apps/bors_github/lib/github/repo.ex
+++ b/apps/bors_github/lib/github/repo.ex
@@ -6,6 +6,7 @@ defmodule BorsNG.GitHub.Repo do
   defstruct(
       id: 0,
       name: "",
+      private: false,
       owner: %{
         id: 0,
         login: "",
@@ -15,6 +16,7 @@ defmodule BorsNG.GitHub.Repo do
   @type t :: %BorsNG.GitHub.Repo{
       id: integer,
       name: bitstring,
+      private: boolean,
       owner: %{
         id: integer,
         login: bitstring,
@@ -32,6 +34,7 @@ defmodule BorsNG.GitHub.Repo do
   def from_json(%{
     "id" => id,
     "full_name" => name,
+    "private" => private,
     "owner" => %{
       "id" => owner_id,
       "login" => owner_login,
@@ -40,6 +43,7 @@ defmodule BorsNG.GitHub.Repo do
       {:ok, %BorsNG.GitHub.Repo{
         id: id,
         name: name,
+        private: private,
         owner: %{
           id: owner_id,
           login: owner_login,


### PR DESCRIPTION
Apparently, there are people using the public instance for private repos.

Not sure if they just have the All Repos option turned on, or if they are knowingly using a random free service for their company's secret sauce. All I know is I don't want to be stuck knowing stuff that's supposed to be NDA'ed.