### PR TITLE
Add clarity to `GITHUB_INTEGRATION_PEM`

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       "description": "GitHub Integration ID"
     },
     "GITHUB_INTEGRATION_PEM": {
-      "description": "GitHub Integration private key (base64-encoded)"
+      "description": "GitHub Integration private key (download the file, encode it with base64, then paste the result here)"
     },
     "GITHUB_WEBHOOK_SECRET": {
       "description": "Github Integration webhook secret"


### PR DESCRIPTION
In the old version, it's confusing whether it wants you to base64-encode the file itself (right)
or copy out the parts of the file that are base64-encoded (wrong).