### PR TITLE
Move the worker processes (Batcher, etc) into an app

### DIFF
--- a/apps/bors_database/config/config.exs
+++ b/apps/bors_database/config/config.exs
@@ -6,7 +6,10 @@
 use Mix.Config
 
 config :bors_database,
-  ecto_repos: [BorsNG.Database.Repo]
+  ecto_repos: [BorsNG.Database.Repo],
+  pubsub: [name: BorsNG.Database.PubSub,
+           adapter: Phoenix.PubSub.PG2,
+           opts: [pool_size: 4]]
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/apps/bors_database/lib/application.ex
+++ b/apps/bors_database/lib/application.ex
@@ -5,6 +5,10 @@ defmodule BorsNG.Database.Application do
 
   use Application
 
+  @pubsub_adapter Application.get_env(:bors_database, :pubsub)[:adapter]
+  @pubsub_name Application.get_env(:bors_database, :pubsub)[:name]
+  @pubsub_params Application.get_env(:bors_database, :pubsub)[:opts]
+
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
@@ -14,6 +18,8 @@ defmodule BorsNG.Database.Application do
     children = [
       # Start the Ecto repository
       supervisor(BorsNG.Database.Repo, []),
+      # Start the pubsub registry
+      supervisor(@pubsub_adapter, [@pubsub_name, @pubsub_params])
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/bors_database/lib/project.ex
+++ b/apps/bors_database/lib/project.ex
@@ -9,6 +9,20 @@ defmodule BorsNG.Database.Project do
 
   @type t :: %Project{}
 
+  @pubsub_name Application.get_env(:bors_database, :pubsub)[:name]
+
+  @doc """
+  After modifying the underlying model,
+  call this to notify the UI.
+  """
+  def ping!(project_id) when not is_binary(project_id) do
+    ping!(to_string(project_id))
+  end
+  def ping!(project_id) do
+    @pubsub_name
+    |> Phoenix.PubSub.broadcast!("project_ping:" <> project_id, "new_msg")
+  end
+
   schema "projects" do
     belongs_to :installation, Installation
     field :repo_xref, :integer

--- a/apps/bors_frontend/config/config.exs
+++ b/apps/bors_frontend/config/config.exs
@@ -24,8 +24,7 @@ config :bors_frontend, BorsNG.Endpoint,
   secret_key_base:
   "RflEtl3q2wkPracTsiqJXfJwu+PtZ6P65kd5rcA7da8KR5Abc/YjB8aZHE4DBxMG",
   render_errors: [view: BorsNG.ErrorView, accepts: ~w(html json)],
-  pubsub: [name: BorsNG.PubSub,
-           adapter: Phoenix.PubSub.PG2]
+  pubsub: [name: BorsNG.Database.PubSub]
 
 config :wobserver,
   mode: :plug,

--- a/apps/bors_frontend/lib/bors_ng.ex
+++ b/apps/bors_frontend/lib/bors_ng.ex
@@ -15,12 +15,6 @@ defmodule BorsNG do
       # Start the endpoint when the application starts
       supervisor(BorsNG.Endpoint, []),
       # worker(BorsNG.Worker, [arg1, arg2, arg3]),
-      supervisor(BorsNG.Batcher.Supervisor, []),
-      worker(BorsNG.Batcher.Registry, []),
-      supervisor(BorsNG.Attemptor.Supervisor, []),
-      worker(BorsNG.Attemptor.Registry, []),
-      supervisor(Task.Supervisor, [[name: BorsNG.Syncer.Supervisor]]),
-      supervisor(Registry, [:unique, BorsNG.Syncer.Registry]),
     ]
 
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html

--- a/apps/bors_frontend/mix.exs
+++ b/apps/bors_frontend/mix.exs
@@ -31,7 +31,6 @@ defmodule BorsNG.Mixfile do
   defp deps do
     [
       {:phoenix, "~> 1.2.1"},
-      {:phoenix_pubsub, "~> 1.0"},
       {:phoenix_ecto, "~> 3.0"},
       {:phoenix_html, "~> 2.6"},
       {:phoenix_live_reload, "~> 1.0", only: :dev},
@@ -43,7 +42,8 @@ defmodule BorsNG.Mixfile do
       {:etoml, [git: "git://github.com/kalta/etoml.git"]},
       {:wobserver, "~> 0.1.7"},
       {:bors_github, [in_umbrella: true]},
-      {:bors_database, [in_umbrella: true]}
+      {:bors_database, [in_umbrella: true]},
+      {:bors_worker, [in_umbrella: true]},
     ]
   end
 end

--- a/apps/bors_frontend/web/channels/project_ping_channel.ex
+++ b/apps/bors_frontend/web/channels/project_ping_channel.ex
@@ -17,16 +17,11 @@ defmodule BorsNG.ProjectPingChannel do
 
   alias BorsNG.Database.Repo
   alias BorsNG.Database.User
-  alias BorsNG.Endpoint
 
   def join("project_ping:" <> project_id, _message, socket) do
     with(
       %{assigns: %{user: user}} <- socket,
       true <- User.has_perm(Repo, user, project_id),
       do: {:ok, socket})
-  end
-
-  def ping!(project_id) do
-    Endpoint.broadcast! "project_ping:#{project_id}", "new_msg", %{}
   end
 end

--- a/apps/bors_frontend/web/command.ex
+++ b/apps/bors_frontend/web/command.ex
@@ -17,8 +17,8 @@ defmodule BorsNG.Command do
   to pull out the commands.
   """
 
-  alias BorsNG.Attemptor
-  alias BorsNG.Batcher
+  alias BorsNG.Worker.Attemptor
+  alias BorsNG.Worker.Batcher
   alias BorsNG.Command
   alias BorsNG.Database.LinkUserProject
   alias BorsNG.Database.Repo
@@ -26,7 +26,7 @@ defmodule BorsNG.Command do
   alias BorsNG.Database.Project
   alias BorsNG.Database.User
   alias BorsNG.GitHub
-  alias BorsNG.Syncer
+  alias BorsNG.Worker.Syncer
 
   defstruct(
     project: nil,

--- a/apps/bors_frontend/web/controllers/project_controller.ex
+++ b/apps/bors_frontend/web/controllers/project_controller.ex
@@ -11,7 +11,7 @@ defmodule BorsNG.ProjectController do
 
   use BorsNG.Web, :controller
 
-  alias BorsNG.Batcher
+  alias BorsNG.Worker.Batcher
   alias BorsNG.Database.Repo
   alias BorsNG.Database.LinkUserProject
   alias BorsNG.Database.Project
@@ -19,7 +19,7 @@ defmodule BorsNG.ProjectController do
   alias BorsNG.Database.Patch
   alias BorsNG.Database.User
   alias BorsNG.GitHub
-  alias BorsNG.Syncer
+  alias BorsNG.Worker.Syncer
 
   # Auto-grab the project and check the permissions
 

--- a/apps/bors_frontend/web/controllers/webhook_controller.ex
+++ b/apps/bors_frontend/web/controllers/webhook_controller.ex
@@ -52,7 +52,7 @@ defmodule BorsNG.WebhookController do
       "test/repo"
       iex> # This has also started a (background) sync of all attached patches.
       iex> # Watch it happen in the user interface.
-      iex> BorsNG.Syncer.wait_hot_spin(proj.id)
+      iex> BorsNG.Worker.Syncer.wait_hot_spin(proj.id)
       iex> patch = Database.Repo.get_by!(Database.Patch, pr_xref: 1)
       iex> patch.title
       "Test"
@@ -63,8 +63,8 @@ defmodule BorsNG.WebhookController do
   @allow_private_repos Application.get_env(
     :bors_frontend, BorsNG)[:allow_private_repos]
 
-  alias BorsNG.Attemptor
-  alias BorsNG.Batcher
+  alias BorsNG.Worker.Attemptor
+  alias BorsNG.Worker.Batcher
   alias BorsNG.Command
   alias BorsNG.Database.Installation
   alias BorsNG.Database.Patch
@@ -72,7 +72,7 @@ defmodule BorsNG.WebhookController do
   alias BorsNG.Database.Repo
   alias BorsNG.Database.LinkUserProject
   alias BorsNG.GitHub
-  alias BorsNG.Syncer
+  alias BorsNG.Worker.Syncer
 
   @doc """
   This action is reached via `/webhook/:provider`
@@ -250,18 +250,18 @@ defmodule BorsNG.WebhookController do
   end
 
   def do_webhook_pr(_conn, %{action: "opened", project: project}) do
-    BorsNG.ProjectPingChannel.ping!(project.id)
+    Project.ping!(project.id)
     :ok
   end
 
   def do_webhook_pr(_conn, %{action: "closed", project: project, patch: p}) do
-    BorsNG.ProjectPingChannel.ping!(project.id)
+    Project.ping!(project.id)
     Repo.update!(Patch.changeset(p, %{open: false}))
     :ok
   end
 
   def do_webhook_pr(_conn, %{action: "reopened", project: project, patch: p}) do
-    BorsNG.ProjectPingChannel.ping!(project.id)
+    Project.ping!(project.id)
     Repo.update!(Patch.changeset(p, %{open: true}))
     :ok
   end

--- a/apps/bors_worker/config/config.exs
+++ b/apps/bors_worker/config/config.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/apps/bors_worker/lib/application.ex
+++ b/apps/bors_worker/lib/application.ex
@@ -1,0 +1,28 @@
+defmodule BorsNG.Worker.Application do
+  @moduledoc """
+  The top-level OPT application for Bors-NG background workers.
+  """
+
+  use Application
+
+  # See http://elixir-lang.org/docs/stable/elixir/Application.html
+  # for more information on OTP Applications
+  def start(_type, _args) do
+    import Supervisor.Spec
+
+    # Define workers and child supervisors to be supervised
+    children = [
+      supervisor(BorsNG.Worker.Batcher.Supervisor, []),
+      worker(BorsNG.Worker.Batcher.Registry, []),
+      supervisor(BorsNG.Worker.Attemptor.Supervisor, []),
+      worker(BorsNG.Worker.Attemptor.Registry, []),
+      supervisor(Task.Supervisor, [[name: BorsNG.Worker.Syncer.Supervisor]]),
+      supervisor(Registry, [:unique, BorsNG.Worker.Syncer.Registry]),
+    ]
+
+    # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :rest_for_one, name: BorsNG.Worker.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/apps/bors_worker/lib/attemptor.ex
+++ b/apps/bors_worker/lib/attemptor.ex
@@ -1,4 +1,4 @@
-defmodule BorsNG.Attemptor do
+defmodule BorsNG.Worker.Attemptor do
   @moduledoc """
   An "Attemptor" manages the set of running attempts (that is, "try jobs").
   It implements this set of rules:
@@ -15,7 +15,7 @@ defmodule BorsNG.Attemptor do
 
   use GenServer
 
-  alias BorsNG.Batcher
+  alias BorsNG.Worker.Batcher
   alias BorsNG.Database.Attempt
   alias BorsNG.Database.AttemptStatus
   alias BorsNG.Database.Repo

--- a/apps/bors_worker/lib/attemptor/registry.ex
+++ b/apps/bors_worker/lib/attemptor/registry.ex
@@ -1,4 +1,4 @@
-defmodule BorsNG.Attemptor.Registry do
+defmodule BorsNG.Worker.Attemptor.Registry do
   @moduledoc """
   The "Attemptor" manages the project's try branch.
   This is the registry of each individual attemptor.
@@ -12,11 +12,11 @@ defmodule BorsNG.Attemptor.Registry do
 
   use GenServer
 
-  alias BorsNG.Attemptor
+  alias BorsNG.Worker.Attemptor
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
 
-  @name BorsNG.Attemptor.Registry
+  @name BorsNG.Worker.Attemptor.Registry
 
   # Public API
 

--- a/apps/bors_worker/lib/attemptor/supervisor.ex
+++ b/apps/bors_worker/lib/attemptor/supervisor.ex
@@ -1,10 +1,10 @@
-defmodule BorsNG.Attemptor.Supervisor do
+defmodule BorsNG.Worker.Attemptor.Supervisor do
   @moduledoc """
   The supervisor of all of the batchers.
   """
   use Supervisor
 
-  @name BorsNG.Attemptor.Supervisor
+  @name BorsNG.Worker.Attemptor.Supervisor
 
   def start_link do
     Supervisor.start_link(__MODULE__, :ok, name: @name)
@@ -16,7 +16,7 @@ defmodule BorsNG.Attemptor.Supervisor do
 
   def init(:ok) do
     children = [
-      worker(BorsNG.Attemptor, [], restart: :temporary)
+      worker(BorsNG.Worker.Attemptor, [], restart: :temporary)
     ]
 
     supervise(children, strategy: :simple_one_for_one)

--- a/apps/bors_worker/lib/batcher/bors_toml.ex
+++ b/apps/bors_worker/lib/batcher/bors_toml.ex
@@ -1,4 +1,4 @@
-defmodule BorsNG.Batcher.BorsToml do
+defmodule BorsNG.Worker.Batcher.BorsToml do
   @moduledoc """
   The format for `bors.toml`. It looks like this:
 
@@ -14,7 +14,7 @@ defmodule BorsNG.Batcher.BorsToml do
   defstruct status: [], block_labels: [], pr_status: [],
     timeout_sec: (60 * 60)
 
-  @type t :: %BorsNG.Batcher.BorsToml{
+  @type t :: %BorsNG.Worker.Batcher.BorsToml{
     status: bitstring,
     timeout_sec: integer}
 
@@ -22,7 +22,7 @@ defmodule BorsNG.Batcher.BorsToml do
     case :etoml.parse(str) do
       {:ok, toml} ->
         toml = Map.new(toml)
-        toml = %BorsNG.Batcher.BorsToml{
+        toml = %BorsNG.Worker.Batcher.BorsToml{
           status: Map.get(toml, "status", []),
           block_labels: Map.get(toml, "block_labels", []),
           pr_status: Map.get(toml, "pr_status", []),

--- a/apps/bors_worker/lib/batcher/get_bors_toml.ex
+++ b/apps/bors_worker/lib/batcher/get_bors_toml.ex
@@ -1,4 +1,4 @@
-defmodule BorsNG.Batcher.GetBorsToml do
+defmodule BorsNG.Worker.Batcher.GetBorsToml do
   @moduledoc """
   Get the bors configuration from a repository.
   This will use `bors.toml`, if available,
@@ -6,7 +6,7 @@ defmodule BorsNG.Batcher.GetBorsToml do
   """
 
   alias BorsNG.GitHub
-  alias BorsNG.Batcher.BorsToml
+  alias BorsNG.Worker.Batcher.BorsToml
 
   @type terror :: :fetch_failed | :parse_failed | :status | :timeout_sec
 

--- a/apps/bors_worker/lib/batcher/message.ex
+++ b/apps/bors_worker/lib/batcher/message.ex
@@ -1,4 +1,4 @@
-defmodule BorsNG.Batcher.Message do
+defmodule BorsNG.Worker.Batcher.Message do
   @moduledoc """
   User-readable strings that go in commit messages and comments.
   """

--- a/apps/bors_worker/lib/batcher/registry.ex
+++ b/apps/bors_worker/lib/batcher/registry.ex
@@ -1,4 +1,4 @@
-defmodule BorsNG.Batcher.Registry do
+defmodule BorsNG.Worker.Batcher.Registry do
   @moduledoc """
   The "Batcher" manages the backlog of batches that each project has.
   This is the registry of each individual batcher.
@@ -12,11 +12,11 @@ defmodule BorsNG.Batcher.Registry do
 
   use GenServer
 
-  alias BorsNG.Batcher
+  alias BorsNG.Worker.Batcher
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
 
-  @name BorsNG.Batcher.Registry
+  @name BorsNG.Worker.Batcher.Registry
 
   # Public API
 

--- a/apps/bors_worker/lib/batcher/state.ex
+++ b/apps/bors_worker/lib/batcher/state.ex
@@ -1,4 +1,4 @@
-defmodule BorsNG.Batcher.State do
+defmodule BorsNG.Worker.Batcher.State do
   @moduledoc """
   The batcher state machine.
   It takes a list of status states,

--- a/apps/bors_worker/lib/batcher/supervisor.ex
+++ b/apps/bors_worker/lib/batcher/supervisor.ex
@@ -1,10 +1,10 @@
-defmodule BorsNG.Batcher.Supervisor do
+defmodule BorsNG.Worker.Batcher.Supervisor do
   @moduledoc """
   The supervisor of all of the batchers.
   """
   use Supervisor
 
-  @name BorsNG.Batcher.Supervisor
+  @name BorsNG.Worker.Batcher.Supervisor
 
   def start_link do
     Supervisor.start_link(__MODULE__, :ok, name: @name)
@@ -16,7 +16,7 @@ defmodule BorsNG.Batcher.Supervisor do
 
   def init(:ok) do
     children = [
-      worker(BorsNG.Batcher, [], restart: :temporary)
+      worker(BorsNG.Worker.Batcher, [], restart: :temporary)
     ]
 
     supervise(children, strategy: :simple_one_for_one)

--- a/apps/bors_worker/lib/syncer.ex
+++ b/apps/bors_worker/lib/syncer.ex
@@ -1,11 +1,11 @@
-defmodule BorsNG.Syncer do
+defmodule BorsNG.Worker.Syncer do
   @moduledoc """
   A background task that pulls a full list of opened pull requests from a repo.
   Patches that don't come up get closed,
   and patches that don't exist get created.
   """
 
-  alias BorsNG.Syncer
+  alias BorsNG.Worker.Syncer
   alias BorsNG.Database.Repo
   alias BorsNG.Database.Patch
   alias BorsNG.Database.Project
@@ -25,7 +25,7 @@ defmodule BorsNG.Syncer do
     open_prs = GitHub.get_open_prs!(conn)
     deltas = synchronize_patches(open_patches, open_prs)
     Enum.each(deltas, &do_synchronize!(project_id, &1))
-    BorsNG.ProjectPingChannel.ping!(project_id)
+    Project.ping!(project_id)
   end
 
   @spec synchronize_patches([%Patch{}], [%GitHub.Pr{}]) ::

--- a/apps/bors_worker/mix.exs
+++ b/apps/bors_worker/mix.exs
@@ -1,9 +1,9 @@
-defmodule BorsNG.Database.Mixfile do
+defmodule BorsNG.Worker.Mixfile do
   use Mix.Project
 
   def project do
     [
-      app: :bors_database,
+      app: :bors_worker,
       version: "0.0.4",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
@@ -12,14 +12,13 @@ defmodule BorsNG.Database.Mixfile do
       elixirc_paths: elixirc_paths(Mix.env),
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
-      aliases: aliases(),
       deps: deps()
     ]
   end
 
   # Configuration for the OTP application.
   def application do
-    [mod: {BorsNG.Database.Application, []},
+    [mod: {BorsNG.Worker.Application, []},
       extra_applications: [:logger]]
   end
 
@@ -30,23 +29,9 @@ defmodule BorsNG.Database.Mixfile do
   # Specifies your project dependencies.
   defp deps do
     [
-      {:phoenix_pubsub, "~> 1.0"},
-      {:postgrex, "~> 0.13.0"},
-      {:ecto, "~> 2.1"}
-    ]
-  end
-
-  # Aliases are shortcuts or tasks specific to the current project.
-  # For example, to create, migrate and run the seeds file at once:
-  #
-  #     $ mix ecto.setup
-  #
-  # See the documentation for `Mix` for more info on aliases.
-  defp aliases do
-    [
-      "ecto.setup": ["ecto.create", "ecto.migrate", "run priv/repo/seeds.exs"],
-      "ecto.reset": ["ecto.drop", "ecto.setup"],
-      "test": ["ecto.create --quiet", "ecto.migrate", "test"]
+      {:etoml, [git: "git://github.com/kalta/etoml.git"]},
+      {:bors_github, [in_umbrella: true]},
+      {:bors_database, [in_umbrella: true]}
     ]
   end
 end

--- a/apps/bors_worker/test/attemptor_test.exs
+++ b/apps/bors_worker/test/attemptor_test.exs
@@ -1,7 +1,7 @@
-defmodule BorsNG.AttemptorTest do
+defmodule BorsNG.Worker.AttemptorTest do
   use BorsNG.ConnCase
 
-  alias BorsNG.Attemptor
+  alias BorsNG.Worker.Attemptor
   alias BorsNG.Database.Attempt
   alias BorsNG.Database.AttemptStatus
   alias BorsNG.Database.Installation

--- a/apps/bors_worker/test/batcher/batcher_test.exs
+++ b/apps/bors_worker/test/batcher/batcher_test.exs
@@ -1,7 +1,7 @@
-defmodule BorsNG.BatcherTest do
-  use BorsNG.ConnCase
+defmodule BorsNG.Worker.BatcherTest do
+  use BorsNG.Worker.TestCase
 
-  alias BorsNG.Batcher
+  alias BorsNG.Worker.Batcher
   alias BorsNG.Database.Batch
   alias BorsNG.Database.Installation
   alias BorsNG.Database.LinkPatchBatch

--- a/apps/bors_worker/test/batcher/bors_toml_test.exs
+++ b/apps/bors_worker/test/batcher/bors_toml_test.exs
@@ -1,44 +1,46 @@
-defmodule BorsNG.BatcherBorsTomlTest do
+defmodule BatcherBorsTomlTest do
   use ExUnit.Case, async: true
 
+  alias BorsNG.Worker.Batcher.BorsToml
+
   test "can parse a single status code" do
-    {:ok, toml} = BorsNG.Batcher.BorsToml.new(~s/status = ["exl"]/)
+    {:ok, toml} = BorsToml.new(~s/status = ["exl"]/)
     assert toml.status == ["exl"]
   end
 
   test "can parse two status codes" do
-    {:ok, toml} = BorsNG.Batcher.BorsToml.new(~s/status = ["exl", "exm"]/)
+    {:ok, toml} = BorsToml.new(~s/status = ["exl", "exm"]/)
     assert toml.status == ["exl", "exm"]
   end
 
   test "default to no status codes" do
-    {:ok, toml} = BorsNG.Batcher.BorsToml.new(~s//)
+    {:ok, toml} = BorsToml.new(~s//)
     assert toml.status == []
   end
 
   test "has a default timeout" do
-    {:ok, toml} = BorsNG.Batcher.BorsToml.new(~s/status = ["exl"]/)
+    {:ok, toml} = BorsToml.new(~s/status = ["exl"]/)
     assert is_integer toml.timeout_sec
   end
 
   test "can parse a custom timeout" do
-    {:ok, toml} = BorsNG.Batcher.BorsToml.new(
+    {:ok, toml} = BorsToml.new(
       ~s/status = ["exl"]\ntimeout_sec = 1/)
     assert toml.timeout_sec == 1
   end
 
   test "recognizes a parse failure" do
-    r = BorsNG.Batcher.BorsToml.new(~s/status = "/)
+    r = BorsToml.new(~s/status = "/)
     assert r == {:error, :parse_failed}
   end
 
   test "recognizes an invalid timeout" do
-    r = BorsNG.Batcher.BorsToml.new(~s/status = []\ntimeout_sec = "3 days"/)
+    r = BorsToml.new(~s/status = []\ntimeout_sec = "3 days"/)
     assert r == {:error, :timeout_sec}
   end
 
   test "recognizes an invalid status" do
-    r = BorsNG.Batcher.BorsToml.new(~s/status = "exl"/)
+    r = BorsToml.new(~s/status = "exl"/)
     assert r == {:error, :status}
   end
 end

--- a/apps/bors_worker/test/batcher/message_test.exs
+++ b/apps/bors_worker/test/batcher/message_test.exs
@@ -1,7 +1,7 @@
-defmodule BorsNG.BatcherMessageTest do
+defmodule BorsNG.Worker.BatcherMessageTest do
   use ExUnit.Case, async: true
 
-  alias BorsNG.Batcher.Message
+  alias BorsNG.Worker.Batcher.Message
 
   test "generate configuration problem message" do
     expected_message = "# Configuration problem\nExample problem"

--- a/apps/bors_worker/test/batcher/state_test.exs
+++ b/apps/bors_worker/test/batcher/state_test.exs
@@ -1,7 +1,7 @@
-defmodule BorsNG.BatcherStateTest do
+defmodule BorsNG.Worker.BatcherStateTest do
   use ExUnit.Case, async: true
 
-  alias BorsNG.Batcher.State
+  alias BorsNG.Worker.Batcher.State
 
   test "summarize" do
     assert State.summarize(:waiting, :waiting) == :waiting

--- a/apps/bors_worker/test/support/test_case.ex
+++ b/apps/bors_worker/test/support/test_case.ex
@@ -1,0 +1,32 @@
+defmodule BorsNG.Worker.TestCase do
+  @moduledoc """
+  This module defines the test case to be used by
+  tests that require setting up a connection.
+
+  Finally, if the test case interacts with the database,
+  it cannot be async. For this reason, every test runs
+  inside a transaction which is reset at the beginning
+  of the test unless the test case is marked as async.
+  """
+
+  use ExUnit.CaseTemplate
+
+  using do
+    quote do
+      alias BorsNG.Database
+      import Ecto
+      import Ecto.Changeset
+      import Ecto.Query
+    end
+  end
+
+  setup tags do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(BorsNG.Database.Repo)
+
+    unless tags[:async] do
+      Ecto.Adapters.SQL.Sandbox.mode(BorsNG.Database.Repo, {:shared, self()})
+    end
+
+    :ok
+  end
+end

--- a/apps/bors_worker/test/syncer_test.exs
+++ b/apps/bors_worker/test/syncer_test.exs
@@ -1,4 +1,4 @@
-defmodule BorsNG.SyncerTest do
+defmodule BorsNG.Worker.SyncerTest do
   use BorsNG.ConnCase
 
   alias BorsNG.GitHub
@@ -6,7 +6,7 @@ defmodule BorsNG.SyncerTest do
   alias BorsNG.Database.Installation
   alias BorsNG.Database.Patch
   alias BorsNG.Database.Project
-  alias BorsNG.Syncer
+  alias BorsNG.Worker.Syncer
 
   setup do
     inst = %Installation{installation_xref: 91}

--- a/apps/bors_worker/test/test_helper.exs
+++ b/apps/bors_worker/test/test_helper.exs
@@ -1,0 +1,3 @@
+ExUnit.start
+
+Ecto.Adapters.SQL.Sandbox.mode(BorsNG.Database.Repo, :manual)


### PR DESCRIPTION
There are a couple advantages to splitting up the code like this:

* Different OTP apps can have different distributed operation policies. For example, we can have a single instance of bors_worker with a fallback, while having two independent instances of bors_frontend.

* There are no circular dependencies allowed. An app lower in the dependency tree can't call a function defined higher in the tree.

* It controls which parts of bors depend on various external ones. Being sure where Phoenix stuff can be touched should help with migrating to Phoenix 1.3.