### PR TITLE
Infer the use of CircleCI

### DIFF
--- a/apps/bors_worker/lib/batcher/get_bors_toml.ex
+++ b/apps/bors_worker/lib/batcher/get_bors_toml.ex
@@ -18,6 +18,7 @@ defmodule BorsNG.Worker.Batcher.GetBorsToml do
         [
           {".travis.yml", "continuous-integration/travis-ci/push"},
           {"appveyor.yml", "continuous-integration/appveyor/branch"},
+          {"circle.yml", "ci/circleci"},
         ]
         |> Enum.filter(fn {file, _} ->
           not is_nil GitHub.get_file!(repo_conn, branch, file) end)

--- a/apps/bors_worker/test/attemptor_test.exs
+++ b/apps/bors_worker/test/attemptor_test.exs
@@ -90,6 +90,20 @@ defmodule BorsNG.Worker.AttemptorTest do
       &(&1.identifier == "continuous-integration/appveyor/branch"))
   end
 
+  test "infer from circle.yml", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        comments: %{1 => []},
+        statuses: %{"iniN" => []},
+        files: %{"trying" => %{"circle.yml" => ""}}
+      }})
+    patch = new_patch(proj, 1, "N")
+    Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
+    [status] = Repo.all(AttemptStatus)
+    assert status.identifier == "ci/circleci"
+  end
+
   test "full runthrough (with polling fallback)", %{proj: proj} do
     # Attempts start running immediately
     GitHub.ServerMock.put_state(%{


### PR DESCRIPTION
Infer status configuration for CircleCI based on the presence of the circle.yml file.

We use CircleCI at my work and I can confirm that the status identifier is indeed `ci/circleci`.

Closes #104.