### PR TITLE
Improve "permission denied" handling

### DIFF
--- a/apps/bors_frontend/lib/error.ex
+++ b/apps/bors_frontend/lib/error.ex
@@ -1,0 +1,7 @@
+defmodule BorsNG.PermissionDeniedError do
+  @moduledoc """
+  When a controller detects that the user is doing something they shouldn't,
+  it raises this error.
+  """
+  defexception plug_status: 403, message: "Permission denied"
+end

--- a/apps/bors_frontend/test/controllers/project_controller_test.exs
+++ b/apps/bors_frontend/test/controllers/project_controller_test.exs
@@ -80,7 +80,7 @@ defmodule BorsNG.ProjectControllerTest do
 
   test "do not show an unlinked project", %{conn: conn, project: project} do
     conn = login conn
-    assert_raise RuntimeError, ~r/Permission denied/, fn ->
+    assert_raise BorsNG.PermissionDeniedError, fn ->
      get conn, project_path(conn, :settings, project)
    end
   end

--- a/apps/bors_frontend/web/command.ex
+++ b/apps/bors_frontend/web/command.ex
@@ -28,6 +28,8 @@ defmodule BorsNG.Command do
   alias BorsNG.GitHub
   alias BorsNG.Worker.Syncer
 
+  import BorsNG.Router.Helpers
+
   defstruct(
     project: nil,
     commenter: nil,
@@ -185,11 +187,21 @@ defmodule BorsNG.Command do
   end
   @spec run(t, cmd, term | nil) :: :ok
   def run(c, _, nil) do
+    login = c.commenter.login
+    url = project_url(
+      BorsNG.Endpoint,
+      :confirm_add_reviewer,
+      c.project,
+      login)
     c.project.repo_xref
     |> Project.installation_connection(Repo)
     |> GitHub.post_comment!(
       c.pr_xref,
-      ":lock: Permission denied")
+      """
+      :lock: Permission denied.
+
+      Existing reviewers: [click here to make #{login} a reviewer](#{url}).
+      """)
   end
   def run(c, :activate, link) do
     run(c, {:activate_by, c.commenter.login}, link)

--- a/apps/bors_frontend/web/controllers/project_controller.ex
+++ b/apps/bors_frontend/web/controllers/project_controller.ex
@@ -161,6 +161,14 @@ defmodule BorsNG.ProjectController do
     |> redirect(to: project_path(conn, :settings, project))
   end
 
+  def confirm_add_reviewer(_, :ro, _, _), do: raise RuntimeError, "Permission denied"
+  def confirm_add_reviewer(conn, :rw, project, %{"login" => login}) do
+    render conn, "confirm-add-reviewer.html",
+      project: project,
+      current_user_id: conn.assigns.user.id,
+      login: login
+  end
+
   def remove_reviewer(_, :ro, _, _), do: raise RuntimeError, "Permission denied"
   def remove_reviewer(conn, :rw, project, %{"user_id" => user_id}) do
     link = Repo.get_by!(

--- a/apps/bors_frontend/web/router.ex
+++ b/apps/bors_frontend/web/router.ex
@@ -64,6 +64,7 @@ defmodule BorsNG.Router do
     put "/:id/settings/branches", ProjectController, :update_branches
     delete "/:id/batches/incomplete", ProjectController, :cancel_all
     post "/:id/reviewer", ProjectController, :add_reviewer
+    get "/:id/add-reviewer/:login", ProjectController, :confirm_add_reviewer
     put "/:id/synchronize", ProjectController, :synchronize
     delete "/:id/reviewer/:user_id", ProjectController, :remove_reviewer
   end

--- a/apps/bors_frontend/web/templates/project/confirm-add-reviewer.html.eex
+++ b/apps/bors_frontend/web/templates/project/confirm-add-reviewer.html.eex
@@ -1,0 +1,44 @@
+<nav>
+
+<div class=wrapper>
+  <a href="<%= project_path(@conn, :index) %>">
+    Repositories
+  </a>
+  ›
+  <a href="https://github.com/<%= @project.name %>/">
+    <%= @project.name %>
+  </a>
+  ›
+  <a href="<%= project_path(@conn, :settings, @project) %>">
+    Settings
+  </a>
+  <h1>
+  Add reviewer
+  </h1>
+</div>
+
+</nav>
+
+<main role=main><div class=wrapper>
+
+<%= if not is_nil get_flash(@conn, :ok) do %>
+<div role="alert" class="alert alert--ok">
+<%= get_flash(@conn, :ok) %>
+</div>
+<% end %>
+
+<%= if not is_nil get_flash(@conn, :error) do %>
+<div role="alert" class="alert alert--error">
+<%= get_flash(@conn, :error) %>
+</div>
+<% end %>
+
+<h2 class=header><%= @login %></h2>
+
+<%= form_for @conn, project_path(@conn, :add_reviewer, @project.id), [as: :reviewer, class: "toolbar"], fn f -> %>
+<%= hidden_input f, :login, value: @login %>
+<%= submit "OK", class: "toolbar-item toolbar-item--add" %>
+<%= link "Cancel", to: project_path(@conn, :settings, @project), class: "toolbar-item toolbar-item--remove" %>
+<% end %>
+
+</div></main>

--- a/apps/bors_frontend/web/views/error_view.ex
+++ b/apps/bors_frontend/web/views/error_view.ex
@@ -14,6 +14,10 @@ defmodule BorsNG.ErrorView do
     "Page not found"
   end
 
+  def render("403.html", _assigns) do
+    "Permission denied"
+  end
+
   def render("500.html", _assigns) do
     "Internal server error"
   end


### PR DESCRIPTION
* When a non-reviewer attempts to post a review, put a link to the dashboard to add them as a reviewer
* When a non-reviewer tries to open the settings page (or click the aforementioned link), respond with a 403 instead of a 500