### PR TITLE
Make the command parser more line-oriented

### DIFF
--- a/apps/bors_frontend/config/config.exs
+++ b/apps/bors_frontend/config/config.exs
@@ -9,11 +9,8 @@ config :bors_frontend, ecto_repos: []
 
 # General application configuration
 config :bors_frontend, BorsNG,
-  activation_phrase: "bors r+",
-  activation_by_phrase: "bors r=",
-  deactivation_phrase: "bors r-",
+  command_trigger: "bors ",
   home_url: "https://bors-ng.github.io/",
-  try_phrase: "bors try",
   github_integration_url:
     "https://github.com/integrations/bors/installations/new",
   allow_private_repos: System.get_env("ALLOW_PRIVATE_REPOS") == "true"

--- a/apps/bors_frontend/test/command_test.exs
+++ b/apps/bors_frontend/test/command_test.exs
@@ -6,34 +6,45 @@ defmodule BorsNG.CommandTest do
   doctest BorsNG.Command
 
   test "reject the empty string" do
-    assert :nomatch == Command.parse("")
-    assert :nomatch == Command.parse(nil)
+    assert [] == Command.parse("")
+    assert [] == Command.parse(nil)
   end
 
   test "reject strings without the phrase" do
-    assert :nomatch == Command.parse("doink!")
+    assert [] == Command.parse("doink!")
   end
 
   test "reject a string that merely starts out like a command" do
-    assert :nomatch == Command.parse("bors doink")
+    assert [] == Command.parse("bors doink")
   end
 
   test "accept the bare command" do
-    assert {:try, ""} == Command.parse("bors try")
-    assert :activate == Command.parse("bors r+")
-    assert :deactivate == Command.parse("bors r-")
+    assert [{:try, ""}] == Command.parse("bors try")
+    assert [:activate] == Command.parse("bors r+")
+    assert [:deactivate] == Command.parse("bors r-")
   end
 
   test "accept the try command with an argument" do
-    assert {:try, "-layout"} == Command.parse("bors try-layout")
+    assert [{:try, "-layout"}] == Command.parse("bors try-layout")
+  end
+
+  test "accept more than one command in a single comment" do
+    expected = [
+      {:try, ""},
+      :deactivate]
+    command = """
+    bors try
+    bors r-
+    """
+    assert expected == Command.parse(command)
   end
 
   test "accept the try command with more argumentation" do
-    assert {:try, " --layout --script"} ==
+    assert [{:try, " --layout --script"}] ==
       Command.parse("bors try --layout --script")
   end
 
-  test "accept the command with a prefix" do
-    assert {:try, "Z"} == Command.parse("Xbors tryZ")
+  test "do not accept the command with a prefix" do
+    assert [] == Command.parse("Xbors tryZ")
   end
 end

--- a/apps/bors_frontend/web/command.ex
+++ b/apps/bors_frontend/web/command.ex
@@ -116,8 +116,8 @@ defmodule BorsNG.Command do
   def parse_cmd("r+" <> _), do: [:activate]
   def parse_cmd("r-" <> _), do: [:deactivate]
   def parse_cmd("r=" <> arguments), do: parse_activation_args(arguments)
-  def parse_cmd("+r" <> _), do: [{:autocorrect, "r+"}, :activate]
-  def parse_cmd("-r" <> _), do: [{:autocorrect, "r-"}, :deactivate]
+  def parse_cmd("+r" <> _), do: [{:autocorrect, "r+"}]
+  def parse_cmd("-r" <> _), do: [{:autocorrect, "r-"}]
   def parse_cmd(_), do: []
 
   @doc ~S"""
@@ -233,6 +233,6 @@ defmodule BorsNG.Command do
     c.project.repo_xref
     |> Project.installation_connection(Repo)
     |> GitHub.post_comment!(
-      c.pr_xref, ~s/Auto-corrected to "#{command}"/)
+      c.pr_xref, ~s/Did you mean "#{command}"?/)
   end
 end


### PR DESCRIPTION
This is a [breaking change], though it's designed to match common usage. It also fixes #173, and it adds autocorrections for common typing errors (with warnings).
