### PR TITLE
fix(webhooks): rename integration events

### DIFF
--- a/apps/bors_frontend/web/controllers/webhook_controller.ex
+++ b/apps/bors_frontend/web/controllers/webhook_controller.ex
@@ -46,7 +46,7 @@ defmodule BorsNG.WebhookController do
       ...>       "id" => 6,
       ...>       "login" => "bors-fanboi",
       ...>       "avatar_url" => "" },
-      ...>     "action" => "created" }}, "github", "integration_installation")
+      ...>     "action" => "created" }}, "github", "installation")
       iex> proj = Database.Repo.get_by!(Database.Project, repo_xref: 14)
       iex> proj.name
       "test/repo"
@@ -90,7 +90,7 @@ defmodule BorsNG.WebhookController do
     :ok
   end
 
-  def do_webhook(conn, "github", "integration_installation") do
+  def do_webhook(conn, "github", "installation") do
     payload = conn.body_params
     installation_xref = payload["installation"]["id"]
     sender = payload["sender"]
@@ -109,7 +109,7 @@ defmodule BorsNG.WebhookController do
     :ok
   end
 
-  def do_webhook(conn, "github", "integration_installation_repositories") do
+  def do_webhook(conn, "github", "installation_repositories") do
     payload = conn.body_params
     installation_xref = payload["installation"]["id"]
     installation = Repo.get_by!(


### PR DESCRIPTION
GitHub's API migrated from integration events to app events, a semantic
change.  The webhooks controller is updated to reflect the naming
convention now used by GitHub.

See the following blog for more infor:
https://developer.github.com/changes/2017-05-22-github-apps-production-ship/

Closes #189.