### PR TITLE
Give repository owners more visibility into their history

### DIFF
--- a/apps/bors_database/lib/batch.ex
+++ b/apps/bors_database/lib/batch.ex
@@ -14,6 +14,7 @@ defmodule BorsNG.Database.Batch do
     field :state, :integer
     field :last_polled, :integer
     field :timeout_at, :integer
+    has_many :patches, LinkPatchBatch
     timestamps()
   end
 

--- a/apps/bors_database/lib/crash.ex
+++ b/apps/bors_database/lib/crash.ex
@@ -1,0 +1,34 @@
+defmodule BorsNG.Database.Crash do
+  @moduledoc """
+  Records of the 
+  Corresponds to a pull request in GitHub.
+
+  A closed patch may not be r+'ed,
+  nor can a patch associated with a completed batch be r+'ed again,
+  though a patch may be merged and r+'ed at the same time.
+  """
+
+  use BorsNG.Database.Model
+
+  @type t :: %Crash{}
+
+  schema "crashes" do
+    belongs_to :project, Project
+    field :crash, :string
+    field :component, :string
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:crash, :component])
+  end
+
+  def all_for_project(project_id) do
+    from c in Crash,
+      where: c.project_id == ^project_id
+  end
+end

--- a/apps/bors_database/lib/model.ex
+++ b/apps/bors_database/lib/model.ex
@@ -24,6 +24,7 @@ defmodule BorsNG.Database.Model do
       alias BorsNG.Database.Attempt
       alias BorsNG.Database.AttemptStatus
       alias BorsNG.Database.Batch
+      alias BorsNG.Database.Crash
       alias BorsNG.Database.Installation
       alias BorsNG.Database.LinkPatchBatch
       alias BorsNG.Database.LinkUserProject

--- a/apps/bors_database/priv/repo/migrations/20170713221213_crash.exs
+++ b/apps/bors_database/priv/repo/migrations/20170713221213_crash.exs
@@ -1,0 +1,12 @@
+defmodule BorsNG.Database.Repo.Migrations.Crash do
+  use Ecto.Migration
+
+  def change do
+    create table(:crashes) do
+      add :project_id, references(:projects, on_delete: :delete_all)
+      add :crash, :text
+      add :component, :string
+      timestamps()
+    end
+  end
+end

--- a/apps/bors_frontend/web/router.ex
+++ b/apps/bors_frontend/web/router.ex
@@ -66,6 +66,7 @@ defmodule BorsNG.Router do
     post "/:id/reviewer", ProjectController, :add_reviewer
     get "/:id/add-reviewer/:login", ProjectController, :confirm_add_reviewer
     put "/:id/synchronize", ProjectController, :synchronize
+    get "/:id/log", ProjectController, :log
     delete "/:id/reviewer/:user_id", ProjectController, :remove_reviewer
   end
 

--- a/apps/bors_frontend/web/static/css/app.css
+++ b/apps/bors_frontend/web/static/css/app.css
@@ -248,3 +248,7 @@ footer {
   margin-bottom: 7px;
   padding-bottom: 8px;
 }
+/* Allow preformatted text to wrap (crash reports) */
+pre {
+  white-space: pre-wrap;
+}

--- a/apps/bors_frontend/web/templates/project/log.html.eex
+++ b/apps/bors_frontend/web/templates/project/log.html.eex
@@ -1,0 +1,62 @@
+<nav>
+
+<div class=wrapper>
+  <a href="<%= project_path(@conn, :index) %>">
+    Repositories
+  </a>
+  ›
+  <h1>
+    <a href="https://github.com/<%= @project.name %>/">
+      <%= @project.name %>
+    </a>
+  </h1>
+</div>
+
+<div class=tabs role=tabs>
+  <%= link "Pull requests", to: project_path(@conn, :show, @project), class: "tab" %>
+  <span class="tab tab--active">History</span>
+  <%= link "Settings", to: project_path(@conn, :settings, @project), class: "tab" %>
+</div>
+
+</nav>
+
+<main role=main><div class=wrapper>
+
+<%= if not is_nil get_flash(@conn, :ok) do %>
+<div role="alert" class="alert alert--ok">
+<%= get_flash(@conn, :ok) %>
+</div>
+<% end %>
+
+<%= if not is_nil get_flash(@conn, :error) do %>
+<div role="alert" class="alert alert--error">
+<%= get_flash(@conn, :error) %>
+</div>
+<% end %>
+
+<table class="table">
+  <tbody>
+<%= for entry <- @entries do %>
+    <tr role=row>
+  <%= case entry do %>
+    <% %BorsNG.Database.Crash{component: component, crash: crash} -> %>
+      <td>Crash</td>
+      <td><%= component %></td>
+      <td><pre><code><%= crash %></code></pre></td>
+    <% %BorsNG.Database.Batch{state: state, patches: patches} -> %>
+      <td>Batch</td>
+      <td><%= stringify_state(state) %></td>
+      <td>
+      <%= for patch <- patches do %>
+        <a href="https://github.com/<%= @project.name %>/pull/<%= patch.pr_xref %>">
+          #<%= patch.pr_xref %>
+        </a>
+      <% end %>
+      </td>
+  <% end %>
+    </tr>
+<% end %>
+  </tbody>
+</table>
+
+</div></main>

--- a/apps/bors_frontend/web/templates/project/settings.html.eex
+++ b/apps/bors_frontend/web/templates/project/settings.html.eex
@@ -14,6 +14,7 @@
 
 <div class=tabs role=tabs>
   <%= link "Pull requests", to: project_path(@conn, :show, @project), class: "tab" %>
+  <%= link "History", to: project_path(@conn, :log, @project), class: "tab" %>
   <span class="tab tab--active">Settings</span>
 </div>
 

--- a/apps/bors_frontend/web/templates/project/show.html.eex
+++ b/apps/bors_frontend/web/templates/project/show.html.eex
@@ -15,6 +15,7 @@
 <div class=tabs role=tabs>
   <span class="tab tab--active">Pull requests</span>
   <%= if @mode == :rw do %>
+  <%= link "History", to: project_path(@conn, :log, @project), class: "tab" %>
   <%= link "Settings", to: project_path(@conn, :settings, @project), class: "tab" %>
   <% end %>
 </div>

--- a/apps/bors_frontend/web/views/project_view.ex
+++ b/apps/bors_frontend/web/views/project_view.ex
@@ -14,6 +14,10 @@ defmodule BorsNG.ProjectView do
     case state do
       0 -> "Waiting to run"
       1 -> "Running"
+      2 -> "Succeeded"
+      3 -> "Failed"
+      4 -> "Canceled"
+      _ -> "Invalid"
     end
   end
 end


### PR DESCRIPTION
![This adds a "History" tab, where crash reports and past batches can be seen](https://user-images.githubusercontent.com/1593513/28193188-b4d63ec8-67ef-11e7-8b83-f1fe3cad54ca.png)

This will log crash reports (so this PR fixes #216, though none of that data exists yet) and allows all the information about past batches (which we have been keeping, BTW, so this tab should already be populated for most long-standing repos).

Next step: tackle #227