### PR TITLE
accept deprecated events

### DIFF
--- a/apps/bors_frontend/web/controllers/webhook_controller.ex
+++ b/apps/bors_frontend/web/controllers/webhook_controller.ex
@@ -90,6 +90,15 @@ defmodule BorsNG.WebhookController do
     :ok
   end
 
+  # 2 hooks for deprecated events, they will be deleted after November 22, 2017
+  def do_webhook(_conn, "github", "integration_installation") do
+    :ok
+  end
+
+  def do_webhook(_conn, "github", "integration_installation_repositories") do
+    :ok
+  end
+
   def do_webhook(conn, "github", "installation") do
     payload = conn.body_params
     installation_xref = payload["installation"]["id"]


### PR DESCRIPTION
let deprecated `integration_installation` and `integration_installation_repositories` come and serve http 200 response instead of http 500

code for this can be deleted after November 22, 2017