### PR TITLE
Use openssl tool to generate the base64 file

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       "description": "GitHub Integration ID"
     },
     "GITHUB_INTEGRATION_PEM": {
-      "description": "GitHub Integration private key (download the file, encode it with base64, then paste the result here)"
+      "description": "GitHub Integration private key (download the file, encode it with `openssl base64 -A -e < key.pem`, then paste the result here)"
     },
     "GITHUB_WEBHOOK_SECRET": {
       "description": "Github Integration webhook secret"


### PR DESCRIPTION
This should be portable, and will avoid the strings nonsense.