### PR TITLE
Add a setting for github app URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The *webhook secret* should be a randomly generated string. The `mix phoenix.gen
 
 GitHub will send a "ping" notification to your webhook endpoint. Since bors is not actually running yet, that will fail. This is expected.
 
-You'll need to jot down the Integration ID (it's between the "Install" button and the "Transfer ownership" button).
+You'll need to jot down the Integration ID (it's between the "Install" button and the "Transfer ownership" button). You'll also need the Public link; this is on your Github App's General settings page and will look like `https://github.com/apps/your-app-name`. There should be a convenient "copy to clipboard" button next to it.
 
 You'll also need to generate the private key. Save the file, because you'll need it later.
 

--- a/app.json
+++ b/app.json
@@ -29,6 +29,9 @@
     "GITHUB_CLIENT_SECRET": {
       "description": "GitHub oAuth client secret"
     },
+    "GITHUB_APP_PUBLIC_LINK": {
+      "description": "Github App Public Link"
+    },
     "GITHUB_INTEGRATION_ID": {
       "description": "GitHub Integration ID"
     },

--- a/apps/bors_frontend/config/config.exs
+++ b/apps/bors_frontend/config/config.exs
@@ -12,7 +12,8 @@ config :bors_frontend, BorsNG,
   command_trigger: "bors",
   home_url: "https://bors.tech/",
   github_integration_url:
-    "https://github.com/integrations/bors/installations/new",
+    "#{System.get_env("GITHUB_APP_PUBLIC_LINK") ||
+       "https://github.com/apps/bors"}/installations/new",
   allow_private_repos: System.get_env("ALLOW_PRIVATE_REPOS") == "true"
 
 # Configures the endpoint


### PR DESCRIPTION
So that when you add repositories to your own instance of bors-ng,
github doesn't add the main instance of bors-ng instead 😱

Fixes #246.