### PR TITLE
Use "merged_at" to determine if a PR is merged

### DIFF
--- a/apps/bors_frontend/test/controllers/webhook_controller_test.exs
+++ b/apps/bors_frontend/test/controllers/webhook_controller_test.exs
@@ -48,7 +48,7 @@ defmodule BorsNG.WebhookControllerTest do
             "id" => 345
           },
         },
-        "merged" => false,
+        "merged_at" => nil,
         "user" => %{
           "id" => 23,
           "login" => "ghost",
@@ -123,7 +123,7 @@ defmodule BorsNG.WebhookControllerTest do
             "id" => 345
           },
         },
-        "merged" => true,
+        "merged_at" => "time",
         "user" => %{
           "id" => 23,
           "login" => "ghost",

--- a/apps/bors_github/lib/github/pr.ex
+++ b/apps/bors_github/lib/github/pr.ex
@@ -63,7 +63,7 @@ defmodule BorsNG.GitHub.Pr do
       "login" => user_login,
       "avatar_url" => user_avatar_url,
     },
-    "merged" => merged,
+    "merged_at" => merged_at,
   }) when is_integer(number) do
     {:ok, %BorsNG.GitHub.Pr{
       number: number,
@@ -89,7 +89,7 @@ defmodule BorsNG.GitHub.Pr do
         login: user_login,
         avatar_url: user_avatar_url,
       },
-      merged: merged
+      merged: not is_nil merged_at
     }}
   end
 


### PR DESCRIPTION
While the "merged" boolean key is included in some webhooks that include a pull request, it is not sent with pull request reviews.

The missing key causes the pull request reviews to produce a 500 error and including a "bors r+" in one would not work.