### PR TITLE
Remove the LICENSE-APACHE link

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,5 @@ You can do it from a PostgreSQL prompt like this:
 # Copyright license
 
 bors-ng is licensed under the Apache license, version 2.0.
-It should be included with the source distribution in [LICENSE-APACHE].
+It should be included with the source distribution in LICENSE-APACHE.
 If it is missing, it is at <http://www.apache.org/licenses/LICENSE-2.0>.
-
-[LICENSE-APACHE]: LICENSE-APACHE


### PR DESCRIPTION
People who want to click the link to open it can use the apache.org link.

More importantly, while the link worked within GitHub, it doesn't work in ExDoc (because ExDoc doesn't include that plain text file), so it caused a broken link in <https://bors.tech/devdocs/bors-ng/readme.html>.