### PR TITLE
Block search engines from the admin console

### DIFF
--- a/apps/bors_frontend/web/static/assets/robots.txt
+++ b/apps/bors_frontend/web/static/assets/robots.txt
@@ -1,2 +1,2 @@
 User-agent: *
-Disallow: /manage/
+Disallow: /


### PR DESCRIPTION
They're just going to get hit with a redirect to the GitHub login page anyway.