### PR TITLE
Do not use `:noreply` with calls

### DIFF
--- a/apps/bors_worker/lib/batcher.ex
+++ b/apps/bors_worker/lib/batcher.ex
@@ -83,7 +83,7 @@ defmodule BorsNG.Worker.Batcher do
         end
     end
 
-    {:noreply, state}
+    {:reply, :ok, state}
   end
 
   def do_handle_cast({:reviewed, patch_id, reviewer}, project_id) do


### PR DESCRIPTION
Never replying to a call is a violation of the `GenServer` API contract.

Fixing this fixes #270, because this bug is causing the command-handler to time out waiting for `set_timeout` to complete before sending the `reviewed` message.