### PR TITLE
Link to the forum instead of the IRC

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -53,7 +53,7 @@ representative at an online or offline event. Representation of a project may be
 further defined and clarified by project maintainers.
 
 Examples of project spaces include all repositories in the bors-ng GitHub
-organization, the `#bors` channel on the Mozilla IRC network, the blog,
+organization, the https://forum.bors.tech/ community site, the blog,
 and any bors meetup.
 
 CONNECTING A GITHUB REPOSITORY TO THE PUBLIC BORS-NG INSTANCE DOES NOT MAKE IT

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -73,6 +73,9 @@ is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 Further details of specific enforcement policies may be posted separately.
 
+On the forum, the built-in "Flagging" mechanism can be used instead of
+emailing the community team.
+
 Project maintainers who do not follow or enforce the Code of Conduct in good
 faith may face temporary or permanent repercussions as determined by other
 members of the project's leadership.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A merge bot for GitHub pull requests
 [Bors-NG] implements a continuous-testing workflow where the master branch never breaks.
 It integrates GitHub pull requests with a tool like [Travis CI] that runs your tests.
 
-* [Home page](https://bors-ng.github.io/)
-* [Getting started](https://bors-ng.github.io/getting-started/)
-* [Developer documentation](https://bors-ng.github.io/devdocs/bors-ng/hacking.html)
+* [Home page](https://bors.tech/)
+* [Getting started](https://bors.tech/getting-started/)
+* [Developer documentation](https://bors.tech/devdocs/bors-ng/hacking.html)
+* [Support forum](https://forum.bors.tech/)
 
 
 # But don't GitHub's Protected Branches already do this?


### PR DESCRIPTION
For the long-term, it's probably better that support is done in a way that's more accessible to search engines and has actual *threading*.