### PR TITLE
use _path url helpers instead of _url in layout template

### DIFF
--- a/apps/bors_frontend/web/templates/layout/app.html.eex
+++ b/apps/bors_frontend/web/templates/layout/app.html.eex
@@ -21,10 +21,10 @@
   <body>
     <header role="banner">
       <div class="wrapper wrapper--mini">
-        <a id=header-logo href="<%= page_url(@conn, :index) %>"><img alt="bors" src='<%= static_path(@conn, "/images/a.svg") %>' width="90" height="25"></a>
+        <a id=header-logo href="<%= page_path(@conn, :index) %>"><img alt="bors" src='<%= static_path(@conn, "/images/a.svg") %>' width="90" height="25"></a>
         <span id=header-user>
 <%= if is_nil @conn.assigns[:user] do %>
-          <a href='<%= auth_url(@conn, :index, "github") %>'>Log in with GitHub</a>
+          <a href='<%= auth_path(@conn, :index, "github") %>'>Log in with GitHub</a>
 <% else %>
           <a href="#user-dropdown" class=drop-down-menu--toggler>
             <img width=25 height=25 src="<%= @conn.assigns.avatar_url %>" alt="" role="presentation">
@@ -34,10 +34,10 @@
 <%= if not is_nil @conn.assigns[:user] do %>
           <div class=drop-down-menu--right><div id="user-dropdown" class="drop-down-menu">
   <%= if @conn.assigns.user.is_admin do %>
-            <a href="<%= admin_url(@conn, :index) %>">Admin</a>
+            <a href="<%= admin_path(@conn, :index) %>">Admin</a>
   <% end %>
-            <a href="<%= project_url(@conn, :index) %>">Repositories</a>
-            <a href="<%= auth_url(@conn, :logout) %>">Log out</a>
+            <a href="<%= project_path(@conn, :index) %>">Repositories</a>
+            <a href="<%= auth_path(@conn, :logout) %>">Log out</a>
 <% end %>
           </div></div>
         </span>


### PR DESCRIPTION
there's no need to use full urls in these links

though actual reason behind this change is i've set my own test instance, configured bors_frontend.url with host public ip, yet links are displayed as `https://admin`