### PR TITLE
Add TaskCluster CI configuration

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -1,0 +1,88 @@
+version: 0
+allowPullRequests: public
+tasks:
+
+  # The bors build queue (test suite)
+  - provisionerId: '{{ taskcluster.docker.provisionerId }}'
+    workerType: '{{ taskcluster.docker.workerType }}'
+    extra:
+      github:
+        events:
+          - push
+        branches:
+          - staging
+          - trying
+    payload:
+      maxRunTime: 3600
+      image: "notriddle/docker-phoenix-elixir-test@sha256:3ce1bf137ee89c4c8f9391442781d44e97c39dbc0c9446586aded299966b3c71"
+      command:
+        - /bin/bash
+        - '--login'
+        - '-c'
+        - >-
+          git clone {{event.head.repo.url}} repo && cd repo &&
+          git config advice.detachedHead false && git checkout {{event.head.sha}} &&
+          bash script/ci
+    metadata:
+      name: Bors-NG test suite
+      description: 'Run unit and integration tests with no browser and a mock GitHub API'
+      owner: '{{ event.head.user.email }}'
+      source: '{{ event.head.repo.url }}'
+
+  # The bors build queue (static analysis)
+  # TODO: cache the PLT files that dialyzer uses
+  - provisionerId: '{{ taskcluster.docker.provisionerId }}'
+    workerType: '{{ taskcluster.docker.workerType }}'
+    extra:
+      github:
+        events:
+          - push
+        branches:
+          - staging
+          - trying
+    payload:
+      maxRunTime: 3600
+      image: notriddle/docker-phoenix-elixir-test
+      command:
+        - /bin/bash
+        - '--login'
+        - '-c'
+        - >-
+          git clone {{event.head.repo.url}} repo && cd repo &&
+          git config advice.detachedHead false && git checkout {{event.head.sha}} &&
+          mix deps.get &&
+          mix dogma && mix dialyzer
+    metadata:
+      name: Bors-NG static analysis
+      description: 'Run static analysis (dogma and dialyzer)'
+      owner: '{{ event.head.user.email }}'
+      source: '{{ event.head.repo.url }}'
+
+  # The pull request builder (dogma)
+  - provisionerId: '{{ taskcluster.docker.provisionerId }}'
+    workerType: '{{ taskcluster.docker.workerType }}'
+    extra:
+      github:
+        events:
+          - pull_request.opened
+          - pull_request.synchronize
+          - pull_request.reopened
+        branches:
+          - master
+    payload:
+      maxRunTime: 3600
+      image: notriddle/docker-phoenix-elixir-test
+      command:
+        - /bin/bash
+        - '--login'
+        - '-c'
+        - >-
+          git clone {{event.head.repo.url}} repo && cd repo &&
+          git config advice.detachedHead false && git checkout {{event.head.sha}} &&
+          mix deps.get &&
+          mix dogma
+    metadata:
+      name: Bors-NG style checker
+      description: 'Run "dogma" against a pull request'
+      owner: '{{ event.head.user.email }}'
+      source: '{{ event.head.repo.url }}'

--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -26,7 +26,7 @@ tasks:
     metadata:
       name: Bors-NG test suite
       description: 'Run unit and integration tests with no browser and a mock GitHub API'
-      owner: '{{ event.head.user.email }}'
+      owner: 'infra@bors.tech'
       source: '{{ event.head.repo.url }}'
 
   # The bors build queue (static analysis)
@@ -55,7 +55,7 @@ tasks:
     metadata:
       name: Bors-NG static analysis
       description: 'Run static analysis (dogma and dialyzer)'
-      owner: '{{ event.head.user.email }}'
+      owner: 'infra@bors.tech'
       source: '{{ event.head.repo.url }}'
 
   # The pull request builder (dogma)

--- a/script/ci
+++ b/script/ci
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -ex
+mix deps.get
+runuser postgres -c "psql -c \"ALTER USER postgres WITH PASSWORD 'Postgres1234'\""
+runuser postgres -c "psql -c \"UPDATE pg_database SET datistemplate = FALSE WHERE datname = 'template1'\""
+runuser postgres -c "psql -c \"DROP DATABASE template1\""
+runuser postgres -c "psql -c \"CREATE DATABASE template1 WITH ENCODING = 'UTF8' TEMPLATE template0\""
+runuser postgres -c "psql -c \"UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template1'\""
+mix test


### PR DESCRIPTION
[TaskCluster] is basically "hard mode" Travis CI. In particular, it supports things like "asking for a particular worker type" (because a certain type of task needs more RAM or whatever), triggering builds from things other than pushing to a branch or opening a PR, and having completely different tasks for pull requests and branches (you'll notice we do so).