### PR TITLE
Shorten the Build ID at the bottom of the screen #286

### DIFF
--- a/apps/bors_frontend/web/templates/layout/app.html.eex
+++ b/apps/bors_frontend/web/templates/layout/app.html.eex
@@ -67,8 +67,8 @@
       <p class=wrapper>
         <span id=footer-version>
           Build:
-          <a href="https://github.com/bors-ng/bors-ng/tree/<%= get_version() %>">
-            <%= get_version() %>
+          <a href="https://github.com/bors-ng/bors-ng/tree/<%= elem(get_version(), 1) %>">
+            <%= elem(get_version(), 0) %>
           </a>
         </span>
         This service is provided for free on a best-effort basis.

--- a/apps/bors_frontend/web/views/layout_view.ex
+++ b/apps/bors_frontend/web/views/layout_view.ex
@@ -7,7 +7,8 @@ defmodule BorsNG.LayoutView do
   use BorsNG.Web, :view
 
   def get_version do
-    get_heroku_commit() || get_git_commit() || get_release_version()
+    hash = get_heroku_commit() || get_git_commit() || get_release_version()
+    {String.slice(hash, 0..6), hash}
   end
 
   def get_heroku_commit do


### PR DESCRIPTION
I have forked the original repo and created a branch, shorten_buildId, to work on the issue.

The attempted fix is to have get_version() return a tuple that contains both a shortened version and the original version.

I am fairly new to Elixir and contributing to open source projects so please let me know if I am doing something wrong or if there are any improvements I can make.