### PR TITLE
Allow Command to parse Bors and bors

### DIFF
--- a/apps/bors_frontend/test/command_test.exs
+++ b/apps/bors_frontend/test/command_test.exs
@@ -41,11 +41,24 @@ defmodule BorsNG.CommandTest do
     assert [:deactivate] == Command.parse("bors r-")
   end
 
+  test "accept the case insensity bare command" do
+    assert [{:try, ""}] == Command.parse("Bors try")
+    assert [:activate] == Command.parse("Bors r+")
+    assert [:deactivate] == Command.parse("Bors r-")
+  end
+
   test "accept priority" do
     assert [{:set_priority, 1}, :activate] == Command.parse("bors r+ p=1")
     assert [{:set_priority, 1}, {:activate_by, "me"}] ==
       Command.parse("bors r=me p=1")
     assert [{:set_priority, 1}] == Command.parse("bors p=1")
+  end
+
+  test "accept priority case insensity" do
+    assert [{:set_priority, 1}, :activate] == Command.parse("Bors r+ p=1")
+    assert [{:set_priority, 1}, {:activate_by, "me"}] ==
+      Command.parse("Bors r=me p=1")
+    assert [{:set_priority, 1}] == Command.parse("Bors p=1")
   end
 
   test "accept negative priority" do

--- a/apps/bors_frontend/web/command.ex
+++ b/apps/bors_frontend/web/command.ex
@@ -107,20 +107,19 @@ defmodule BorsNG.Command do
   def parse(comment) do
     comment
     |> String.splitter("\n")
-    |> Enum.flat_map(fn
-      @command_trigger <> " " <> cmd ->
-        trim_and_parse_cmd(cmd)
-      @command_trigger <> ": " <> cmd ->
-        trim_and_parse_cmd(cmd)
-      _ -> []
+    |> Enum.flat_map(fn(string) ->
+      trim_and_parse_cmd(Regex.named_captures(regex(), string))
     end)
   end
 
-  def trim_and_parse_cmd(cmd) do
+  def regex, do: ~r/^#{@command_trigger}:?\s(?<command>.+)/i
+
+  def trim_and_parse_cmd(%{"command" => cmd}) do
     cmd
     |> String.trim()
     |> parse_cmd()
   end
+  def trim_and_parse_cmd(_), do: []
 
   def parse_cmd("try" <> arguments), do: [{:try, arguments}]
   def parse_cmd("r+ p=" <> rest), do: parse_priority(rest) ++ [:activate]


### PR DESCRIPTION
#308 

I decided to use `Regex` in this case because it seems the most simple way to keep functionality without changing too much code.

@notriddle please add as many comments as need it.