### PR TITLE
Get the same navigation bar from the home page onto the app

### DIFF
--- a/apps/bors_frontend/web/static/css/app.css
+++ b/apps/bors_frontend/web/static/css/app.css
@@ -1,5 +1,25 @@
 /* always show the scrollbar on the side; avoids ugly jumping */
 html{overflow-y:scroll}
+/* Use underline-on-hover for links.
+   This is used for consistency, since fill-link breaks outlines. */
+:link, :visited {
+  text-decoration: none;
+  color: #4d76ae;
+}
+:link:focus {
+  color: #33b5e5;
+}
+:visited {
+  color: #ae3d96;
+}
+:visited:focus {
+  color: #b533e5;
+}
+:link:hover, :link:focus,
+:visited:hover, :visited:focus {
+  text-decoration: underline;
+  outline: none;
+}
 /* Should be used inside of the header, main, and footer */
 .wrapper {
   max-width: 1000px;
@@ -19,18 +39,47 @@ header {
 #header-user {
   float: right;
 }
-#header-user > a, #header-user img, #header-logo {
+.header-link, #header-user img, #header-logo {
   vertical-align: middle;
   line-height: 25px;
   height: 25px;
   display: inline-block;
 }
+#header-sections {
+  padding-left: 8px;
+}
+.header-link, .drop-down-menu > a {
+  color: #333;
+  padding: 0 8px;
+  transition: color 0.15s ease-in-out, background-color 0.15s ease-in-out;
+}
+.header-link + .header-link-container {
+  margin-left: 8px;
+}
+a.header-link-container:hover,
+a.header-link-container:active,
+a.header-link-container:focus {
+  text-decoration: none;
+}
+a.header-link:hover,
+a.header-link:active,
+a.header-link:focus,
+a.header-link-container:hover .header-link,
+a.header-link-container:active .header-link,
+a.header-link-container:focus .header-link,
+.drop-down-menu > a:hover,
+.drop-down-menu > a:active,
+.drop-down-menu > a:focus {
+  color: #fff;
+  background: #000;
+  text-decoration: none;
+}
 .drop-down-menu {
   display: none;
   position: fixed;
   background: #fff;
-  border: solid 1px #CCC;
   padding: 8px 0;
+  box-shadow: 0 1px 4px #666;
 }
 .drop-down-menu:target, .drop-down-menu--open {
   display: block;
@@ -101,29 +150,6 @@ footer {
 .close-button:active,
 .close-button:focus {
   color: #df3600;
-}
-/* Use underline-on-hover for links.
-   This is used for consistency, since fill-link breaks outlines. */
-:link, :visited {
-  text-decoration: none;
-  color: #4d76ae;
-}
-:link:focus {
-  color: #33b5e5;
-}
-:visited {
-  color: #ae3d96;
-}
-:visited:focus {
-  color: #b533e5;
-}
-:link:hover, :link:focus,
-:visited:hover, :visited:focus {
-  text-decoration: underline;
-  outline: none;
-}
-:link:focus img, :visited:focus img {
-  outline: dotted;
 }
 /* The tab bar. */
 .tabs {
@@ -304,4 +330,15 @@ pre {
 /* Timestamps that show local time inline and UTC on hover */
 time[title] {
   border-bottom: dotted 1px #999;
+}
+.show-on-narrow {
+  display: none !important;
+}
+@media (max-width: 800px) {
+  .hide-on-narrow {
+    display: none !important;
+  }
+  .show-on-narrow {
+    display: block !important;
+  }
 }

--- a/apps/bors_frontend/web/templates/layout/app.html.eex
+++ b/apps/bors_frontend/web/templates/layout/app.html.eex
@@ -39,13 +39,24 @@
     <header role="banner">
       <div class="wrapper wrapper--mini">
         <a id=header-logo href="<%= page_path(@conn, :index) %>"><img alt="bors" src='<%= static_path(@conn, "/images/a.svg") %>' width="90" height="25"></a>
+        <span id=header-sections class=hide-on-narrow>
+          <a class=header-link href="https://bors.tech">Home</a>
+          <a class=header-link href="https://forum.bors.tech">Forum</a>
+          <a class=header-link href="https://bors.tech/documentation/getting-started/">Docs</a>
+          <b class=header-link>Dashboard</b>
+        </span>
         <span id=header-user>
 <%= if is_nil @conn.assigns[:user] do %>
-          <a href='<%= auth_path(@conn, :index, "github") %>'>Log in with GitHub</a>
+          <a class=header-link href='<%= auth_path(@conn, :index, "github") %>'>Log in with GitHub</a>
 <% else %>
-          <a href="#user-dropdown" class=drop-down-menu--toggler>
+  <%= if @conn.path_info == ["repositories"] do %>
+          <b class="header-link hide-on-narrow">Repositories</b>
+  <% else %>
+          <a class="header-link hide-on-narrow" href="<%= project_path(@conn, :index) %>">Repositories</a>
+  <% end %>
+          <a href="#user-dropdown" class="header-link-container drop-down-menu--toggler">
             <img width=25 height=25 src="<%= @conn.assigns.avatar_url %>" alt="" role="presentation">
-            <%= @conn.assigns.user.login %> ▾
+            <span class=header-link><%= @conn.assigns.user.login %> ▾</span>
           </a>
 <% end %>
 <%= if not is_nil @conn.assigns[:user] do %>
@@ -53,7 +64,7 @@
   <%= if @conn.assigns.user.is_admin do %>
             <a href="<%= admin_path(@conn, :index) %>">Admin</a>
   <% end %>
-            <a href="<%= project_path(@conn, :index) %>">Repositories</a>
+            <a class=show-on-narrow href="<%= project_path(@conn, :index) %>">Repositories</a>
             <a href="<%= auth_path(@conn, :logout) %>">Log out</a>
 <% end %>
           </div></div>
@@ -63,7 +74,15 @@
 
     <%= render @view_module, @view_template, assigns %>
 
-    <footer role="note">
+    <footer role=navigation class=show-on-narrow>
+      <div class=wrapper>
+        <a class=header-link href="https://bors.tech">Home</a>
+        <a class=header-link href="https://forum.bors.tech">Forum</a>
+        <a class=header-link href="https://bors.tech/documentation/getting-started/">Docs</a>
+        <b class=header-link>Dashboard</b>
+      </div>
+    </footer>
+    <footer role=note>
       <p class=wrapper>
         <span id=footer-version>
           Build:

--- a/apps/bors_frontend/web/templates/project/confirm-add-reviewer.html.eex
+++ b/apps/bors_frontend/web/templates/project/confirm-add-reviewer.html.eex
@@ -1,10 +1,6 @@
 <nav>
 
 <div class=wrapper>
-  <a href="<%= project_path(@conn, :index) %>">
-    Repositories
-  </a>
-  ›
   <a href="https://github.com/<%= @project.name %>/">
     <%= @project.name %>
   </a>

--- a/apps/bors_frontend/web/templates/project/index.html.eex
+++ b/apps/bors_frontend/web/templates/project/index.html.eex
@@ -1,7 +1,3 @@
-<nav><div class=wrapper>
-<h1>Repositories</h1>
-</div></nav>
-
 <main role=main><div class=wrapper>
 
 <div class=toolbar>

--- a/apps/bors_frontend/web/templates/project/log.html.eex
+++ b/apps/bors_frontend/web/templates/project/log.html.eex
@@ -1,10 +1,6 @@
 <nav>
 
 <div class=wrapper>
-  <a href="<%= project_path(@conn, :index) %>">
-    Repositories
-  </a>
-  ›
   <h1>
     <a href="https://github.com/<%= @project.name %>/">
       <%= @project.name %>

--- a/apps/bors_frontend/web/templates/project/settings.html.eex
+++ b/apps/bors_frontend/web/templates/project/settings.html.eex
@@ -1,10 +1,6 @@
 <nav>
 
 <div class=wrapper>
-  <a href="<%= project_path(@conn, :index) %>">
-    Repositories
-  </a>
-  ›
   <h1>
     <a href="https://github.com/<%= @project.name %>/">
       <%= @project.name %>

--- a/apps/bors_frontend/web/templates/project/show.html.eex
+++ b/apps/bors_frontend/web/templates/project/show.html.eex
@@ -1,9 +1,5 @@
 <nav>
 <div class=wrapper>
-  <a href="<%= project_path(@conn, :index) %>">
-    Repositories
-  </a>
-  ›
   <h1>
     <a href="https://github.com/<%= @project.name %>/">
       <%= @project.name %>
@@ -23,7 +19,7 @@
 
 <%= if empty?(@unbatched_patches) and empty?(@batches) do %>
   Nothing to see here
-<%= else %>
+<% else %>
 <table class="table">
 <%= if @unbatched_patches != [] do %>
   <thead>


### PR DESCRIPTION
This also makes the Repositories screen more accessible, by surfacing it out of the menu (on screen where that fits).

![wide-mode](https://user-images.githubusercontent.com/1593513/32091205-ffddd02e-baa7-11e7-95d6-17464a508185.PNG)

![narrow-mode](https://user-images.githubusercontent.com/1593513/32091209-03e832a4-baa8-11e7-9408-08bc516055b0.PNG)
