### PR TITLE
Add a second, less-permissive mode for users to be in

### DIFF
--- a/apps/bors_database/lib/context.ex
+++ b/apps/bors_database/lib/context.ex
@@ -25,6 +25,7 @@ defmodule BorsNG.Database.Context do
       alias BorsNG.Database.Installation
       alias BorsNG.Database.LinkPatchBatch
       alias BorsNG.Database.LinkUserProject
+      alias BorsNG.Database.LinkMemberProject
       alias BorsNG.Database.Patch
       alias BorsNG.Database.Project
       alias BorsNG.Database.Repo

--- a/apps/bors_database/lib/context/permission.ex
+++ b/apps/bors_database/lib/context/permission.ex
@@ -21,19 +21,19 @@ defmodule BorsNG.Database.Context.Permission do
       where: u.id == l.user_id)
   end
 
-  def has_permission?(:member, user, patch) do
+  def permission?(:member, user, patch) do
     %User{id: user_id} = user
     %Patch{project_id: project_id} = patch
     project_member?(user_id, project_id) or
-      has_permission?(:reviewer, user, patch)
+      permission?(:reviewer, user, patch)
   end
-  def has_permission?(:reviewer, user, patch) do
+  def permission?(:reviewer, user, patch) do
     %User{id: user_id} = user
     %Patch{id: patch_id, project_id: project_id} = patch
     project_reviewer?(user_id, project_id) or
       patch_delegated_reviewer?(user_id, patch_id)
   end
-  def has_permission?(:none, _, _) do
+  def permission?(:none, _, _) do
     true
   end
 

--- a/apps/bors_database/lib/context/permission.ex
+++ b/apps/bors_database/lib/context/permission.ex
@@ -8,6 +8,19 @@ defmodule BorsNG.Database.Context.Permission do
 
   use BorsNG.Database.Context
 
+  def list_users_for_project(:member, project_id) do
+    Repo.all(from u in User,
+      join: l in LinkMemberProject,
+      where: l.project_id == ^project_id,
+      where: u.id == l.user_id)
+  end
+  def list_users_for_project(:reviewer, project_id) do
+    Repo.all(from u in User,
+      join: l in LinkUserProject,
+      where: l.project_id == ^project_id,
+      where: u.id == l.user_id)
+  end
+
   def has_permission?(:member, user, patch) do
     %User{id: user_id} = user
     %Patch{project_id: project_id} = patch

--- a/apps/bors_database/lib/link_member_project.ex
+++ b/apps/bors_database/lib/link_member_project.ex
@@ -1,0 +1,27 @@
+defmodule BorsNG.Database.LinkMemberProject do
+  @moduledoc """
+  The connection between a project and its reviewers.
+
+  People with this link can bring up the dashboard page and settings
+  for a project, and can r+ a commit. Otherwise, they can't.
+  """
+
+  use BorsNG.Database.Model
+
+  schema "link_member_project" do
+    belongs_to :user, User
+    belongs_to :project, Project
+  end
+
+  @doc """
+  Builds a changeset based on the `struct` and `params`.
+  """
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, [:user_id, :project_id])
+    |> validate_required([:user_id, :project_id])
+    |> unique_constraint(
+      :user_id,
+      name: :link_member_project_user_id_project_id_index)
+  end
+end

--- a/apps/bors_database/lib/project.ex
+++ b/apps/bors_database/lib/project.ex
@@ -17,7 +17,7 @@ defmodule BorsNG.Database.Project do
     ping!(to_string(project_id))
   end
   def ping!(project_id) do
-    BorsNG.Endpoint.broadcast!("project_ping:1", "new_msg", %{})
+    BorsNG.Endpoint.broadcast!("project_ping:#{project_id}", "new_msg", %{})
   end
 
   schema "projects" do

--- a/apps/bors_database/lib/user.ex
+++ b/apps/bors_database/lib/user.ex
@@ -17,13 +17,6 @@ defmodule BorsNG.Database.User do
     timestamps()
   end
 
-  def by_project(project_id) do
-    from u in User,
-      join: l in LinkUserProject,
-      where: l.project_id == ^project_id,
-      where: u.id == l.user_id
-  end
-
   def has_perm(_repo, %User{is_admin: true}, _project_id) do
     true
   end

--- a/apps/bors_database/priv/repo/migrations/20171102204729_link_member_project.exs
+++ b/apps/bors_database/priv/repo/migrations/20171102204729_link_member_project.exs
@@ -1,0 +1,12 @@
+defmodule BorsNG.Database.Repo.Migrations.LinkMemberProject do
+  use Ecto.Migration
+
+  def change do
+    create table(:link_member_project) do
+      add :project_id, references(:projects, on_delete: :delete_all)
+      add :user_id, references(:users, on_delete: :delete_all)
+    end
+    create index(:link_member_project, [:user_id, :project_id],
+      name: :link_member_project_user_id_project_id_index, unique: true)
+  end
+end

--- a/apps/bors_database/test/context/permission_test.exs
+++ b/apps/bors_database/test/context/permission_test.exs
@@ -4,6 +4,7 @@ defmodule BorsNG.Database.Context.PermissionTest do
   alias BorsNG.Database.Context.Permission
   alias BorsNG.Database.Installation
   alias BorsNG.Database.LinkUserProject
+  alias BorsNG.Database.LinkMemberProject
   alias BorsNG.Database.Patch
   alias BorsNG.Database.Project
   alias BorsNG.Database.User
@@ -29,18 +30,28 @@ defmodule BorsNG.Database.Context.PermissionTest do
 
   test "user does not have permission by default", params do
     %{patch: patch, user: user} = params
-    refute Permission.permission_to_approve_patch?(user, patch)
+    refute Permission.has_permission?(:reviewer, user, patch)
+    refute Permission.has_permission?(:member, user, patch)
   end
 
   test "reviewers have permission", params do
     %{project: project, patch: patch, user: user} = params
     Repo.insert!(%LinkUserProject{user: user, project: project})
-    assert Permission.permission_to_approve_patch?(user, patch)
+    assert Permission.has_permission?(:reviewer, user, patch)
+    assert Permission.has_permission?(:member, user, patch)
   end
 
   test "delegated users have permission", params do
     %{patch: patch, user: user} = params
     Repo.insert!(%UserPatchDelegation{user: user, patch: patch})
-    assert Permission.permission_to_approve_patch?(user, patch)
+    assert Permission.has_permission?(:reviewer, user, patch)
+    assert Permission.has_permission?(:member, user, patch)
+  end
+
+  test "members have partial permission", params do
+    %{project: project, patch: patch, user: user} = params
+    Repo.insert!(%LinkMemberProject{user: user, project: project})
+    refute Permission.has_permission?(:reviewer, user, patch)
+    assert Permission.has_permission?(:member, user, patch)
   end
 end

--- a/apps/bors_database/test/context/permission_test.exs
+++ b/apps/bors_database/test/context/permission_test.exs
@@ -30,28 +30,28 @@ defmodule BorsNG.Database.Context.PermissionTest do
 
   test "user does not have permission by default", params do
     %{patch: patch, user: user} = params
-    refute Permission.has_permission?(:reviewer, user, patch)
-    refute Permission.has_permission?(:member, user, patch)
+    refute Permission.permission?(:reviewer, user, patch)
+    refute Permission.permission?(:member, user, patch)
   end
 
   test "reviewers have permission", params do
     %{project: project, patch: patch, user: user} = params
     Repo.insert!(%LinkUserProject{user: user, project: project})
-    assert Permission.has_permission?(:reviewer, user, patch)
-    assert Permission.has_permission?(:member, user, patch)
+    assert Permission.permission?(:reviewer, user, patch)
+    assert Permission.permission?(:member, user, patch)
   end
 
   test "delegated users have permission", params do
     %{patch: patch, user: user} = params
     Repo.insert!(%UserPatchDelegation{user: user, patch: patch})
-    assert Permission.has_permission?(:reviewer, user, patch)
-    assert Permission.has_permission?(:member, user, patch)
+    assert Permission.permission?(:reviewer, user, patch)
+    assert Permission.permission?(:member, user, patch)
   end
 
   test "members have partial permission", params do
     %{project: project, patch: patch, user: user} = params
     Repo.insert!(%LinkMemberProject{user: user, project: project})
-    refute Permission.has_permission?(:reviewer, user, patch)
-    assert Permission.has_permission?(:member, user, patch)
+    refute Permission.permission?(:reviewer, user, patch)
+    assert Permission.permission?(:member, user, patch)
   end
 end

--- a/apps/bors_frontend/test/command_test.exs
+++ b/apps/bors_frontend/test/command_test.exs
@@ -101,6 +101,15 @@ defmodule BorsNG.CommandTest do
     assert [] == Command.parse("Xbors tryZ")
   end
 
+  test "command permissions" do
+    assert :none == Command.required_permission_level([])
+    assert :none == Command.required_permission_level([:ping])
+    assert :member == Command.required_permission_level([{:try, ""}])
+    assert :member == Command.required_permission_level([{:try, ""}, :ping])
+    assert :reviewer == Command.required_permission_level([:approve, {:try, ""}])
+    assert :reviewer == Command.required_permission_level([{:try, ""}, :approve])
+  end
+
   test "running ping command should post comment", %{proj: proj} do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{

--- a/apps/bors_frontend/test/command_test.exs
+++ b/apps/bors_frontend/test/command_test.exs
@@ -106,8 +106,10 @@ defmodule BorsNG.CommandTest do
     assert :none == Command.required_permission_level([:ping])
     assert :member == Command.required_permission_level([{:try, ""}])
     assert :member == Command.required_permission_level([{:try, ""}, :ping])
-    assert :reviewer == Command.required_permission_level([:approve, {:try, ""}])
-    assert :reviewer == Command.required_permission_level([{:try, ""}, :approve])
+    assert :reviewer ==
+      Command.required_permission_level([:approve, {:try, ""}])
+    assert :reviewer ==
+      Command.required_permission_level([{:try, ""}, :approve])
   end
 
   test "running ping command should post comment", %{proj: proj} do

--- a/apps/bors_frontend/web/command.ex
+++ b/apps/bors_frontend/web/command.ex
@@ -286,7 +286,7 @@ defmodule BorsNG.Command do
 
     cmd_list
     |> required_permission_level()
-    |> Permission.has_permission?(c.commenter, c.patch)
+    |> Permission.permission?(c.commenter, c.patch)
     |> if do
       Enum.each(cmd_list, &run(c, &1))
     else

--- a/apps/bors_frontend/web/command.ex
+++ b/apps/bors_frontend/web/command.ex
@@ -284,18 +284,43 @@ defmodule BorsNG.Command do
     |> fetch_patch()
     cmd_list = parse(c.comment)
 
-    cond do
-      cmd_list == [] ->
-        :ok
-      cmd_list == [:ping] ->
-        run(c, :ping)
-      Permission.permission_to_approve_patch?(c.commenter, c.patch) ->
-        Enum.each(cmd_list, &run(c, &1))
-      true ->
-        permission_denied(c)
+    cmd_list
+    |> required_permission_level()
+    |> Permission.has_permission?(c.commenter, c.patch)
+    |> if do
+      Enum.each(cmd_list, &run(c, &1))
+    else
+      permission_denied(c)
     end
   end
-  @spec run(t, cmd) :: :ok
+
+  def required_permission_level_cmd(:ping) do
+    :none
+  end
+  def required_permission_level_cmd({:autocorrect, _}) do
+    :none
+  end
+  def required_permission_level_cmd({:try, _}) do
+    :member
+  end
+  def required_permission_level_cmd(_) do
+    :reviewer
+  end
+
+  def required_permission_level(cmd_list) do
+    cmd_list
+    |> Enum.reduce(:none, fn cmd, perm ->
+      new_perm = cmd |> required_permission_level_cmd()
+      case {perm, new_perm} do
+        {:none, new_perm} -> new_perm
+        {perm, :none} -> perm
+        {_, :reviewer} -> :reviewer
+        {:reviewer, _} -> :reviewer
+        {p, p} -> p
+      end
+    end)
+  end
+
   def permission_denied(c) do
     login = c.commenter.login
     url = project_url(
@@ -313,6 +338,8 @@ defmodule BorsNG.Command do
       Existing reviewers: [click here to make #{login} a reviewer](#{url})
       """)
   end
+
+  @spec run(t, cmd) :: :ok
   def run(c, :activate) do
     run(c, {:activate_by, c.commenter.login})
   end
@@ -363,6 +390,7 @@ defmodule BorsNG.Command do
     end
     delegate_to(c, delegatee)
   end
+
   def delegate_to(c, delegatee) do
     Permission.delegate(delegatee, c.patch)
     c.project.repo_xref

--- a/apps/bors_frontend/web/controllers/project_controller.ex
+++ b/apps/bors_frontend/web/controllers/project_controller.ex
@@ -134,12 +134,14 @@ defmodule BorsNG.ProjectController do
         |> put_flash(:ok, "Successfully updated branches")
         |> redirect(to: project_path(conn, :settings, project))
       {:error, changeset} ->
-        reviewers = Repo.all(User.by_project(project.id))
+        reviewers = Permission.list_users_for_project(:reviewer, project.id)
+        members = Permission.list_users_for_project(:member, project.id)
         conn
         |> put_flash(:error, "Cannot update branches")
         |> render("settings.html",
           project: project,
           reviewers: reviewers,
+          members: members,
           current_user_id: conn.assigns.user.id,
           update_branches: changeset)
     end

--- a/apps/bors_frontend/web/controllers/project_controller.ex
+++ b/apps/bors_frontend/web/controllers/project_controller.ex
@@ -12,7 +12,9 @@ defmodule BorsNG.ProjectController do
   use BorsNG.Web, :controller
 
   alias BorsNG.Worker.Batcher
+  alias BorsNG.Database.Context.Permission
   alias BorsNG.Database.Repo
+  alias BorsNG.Database.LinkMemberProject
   alias BorsNG.Database.LinkUserProject
   alias BorsNG.Database.Project
   alias BorsNG.Database.Batch
@@ -82,10 +84,12 @@ defmodule BorsNG.ProjectController do
 
   def settings(_, :ro, _, _), do: raise BorsNG.PermissionDeniedError
   def settings(conn, :rw, project, _params) do
-    reviewers = Repo.all(User.by_project(project.id))
+    reviewers = Permission.list_users_for_project(:reviewer, project.id)
+    members = Permission.list_users_for_project(:member, project.id)
     render conn, "settings.html",
       project: project,
       reviewers: reviewers,
+      members: members,
       current_user_id: conn.assigns.user.id,
       update_branches: Project.changeset_branches(project)
   end
@@ -141,6 +145,7 @@ defmodule BorsNG.ProjectController do
     end
   end
 
+
   def add_reviewer(_, :ro, _, _), do: raise BorsNG.PermissionDeniedError
   def add_reviewer(conn, :rw, project, %{"reviewer" => %{"login" => ""}}) do
     conn
@@ -188,6 +193,53 @@ defmodule BorsNG.ProjectController do
     |> redirect(to: project_path(conn, :settings, project))
   end
 
+  def add_member(_, :ro, _, _), do: raise BorsNG.PermissionDeniedError
+  def add_member(conn, :rw, project, %{"member" => %{"login" => ""}}) do
+    conn
+    |> put_flash(:error, "Please enter a GitHub user's nickname")
+    |> redirect(to: project_path(conn, :settings, project))
+  end
+  def add_member(conn, :rw, project, %{"member" => %{"login" => login}}) do
+    user = case Repo.get_by(User, login: login) do
+      nil ->
+        {:installation, project.installation.installation_xref}
+        |> GitHub.get_user_by_login!(login)
+        |> case do
+          nil -> nil
+          gh_user ->
+            case Repo.get_by(User, user_xref: gh_user.id) do
+              nil ->
+                User.changeset(%User{}, %{
+                  user_xref: gh_user.id,
+                  login: gh_user.login
+                })
+                |> Repo.insert!()
+              user -> user
+            end
+        end
+      user -> user
+    end
+    {state, msg} = case user do
+      nil ->
+        {:error, "GitHub user not found; maybe you typo-ed?"}
+      user ->
+        %LinkMemberProject{}
+        |> LinkMemberProject.changeset(%{
+          user_id: user.id,
+          project_id: project.id})
+        |> Repo.insert()
+        |> case do
+          {:error, _} ->
+            {:error, "This user is already a member"}
+          {:ok, _login} ->
+            {:ok, "Successfully added #{user.login} as a member"}
+        end
+    end
+    conn
+    |> put_flash(state, msg)
+    |> redirect(to: project_path(conn, :settings, project))
+  end
+
   def confirm_add_reviewer(_, :ro, _, _) do
     raise BorsNG.PermissionDeniedError
   end
@@ -207,6 +259,18 @@ defmodule BorsNG.ProjectController do
     Repo.delete!(link)
     conn
     |> put_flash(:ok, "Removed reviewer")
+    |> redirect(to: project_path(conn, :settings, project))
+  end
+
+  def remove_member(_, :ro, _, _), do: raise BorsNG.PermissionDeniedError
+  def remove_member(conn, :rw, project, %{"user_id" => user_id}) do
+    link = Repo.get_by!(
+      LinkMemberProject,
+      project_id: project.id,
+      user_id: user_id)
+    Repo.delete!(link)
+    conn
+    |> put_flash(:ok, "Removed member")
     |> redirect(to: project_path(conn, :settings, project))
   end
 

--- a/apps/bors_frontend/web/router.ex
+++ b/apps/bors_frontend/web/router.ex
@@ -64,10 +64,12 @@ defmodule BorsNG.Router do
     put "/:id/settings/branches", ProjectController, :update_branches
     delete "/:id/batches/incomplete", ProjectController, :cancel_all
     post "/:id/reviewer", ProjectController, :add_reviewer
+    post "/:id/member", ProjectController, :add_member
     get "/:id/add-reviewer/:login", ProjectController, :confirm_add_reviewer
     put "/:id/synchronize", ProjectController, :synchronize
     get "/:id/log", ProjectController, :log
     delete "/:id/reviewer/:user_id", ProjectController, :remove_reviewer
+    delete "/:id/member/:user_id", ProjectController, :remove_member
   end
 
   scope @wobserver_url, Wobserver do

--- a/apps/bors_frontend/web/static/css/app.css
+++ b/apps/bors_frontend/web/static/css/app.css
@@ -29,6 +29,18 @@ html{overflow-y:scroll}
 .wrapper--mini {
   padding: 8px 20px;
 }
+/* split-screen effect, sizing things to not get any narrower than reasonable */
+.split {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin: -16px -20px;
+}
+.split-item {
+  margin: 16px 20px;
+  width: 400px;
+  flex-grow: 1;
+}
 /* The header, nav bar, and footer */
 header, nav {
   border-bottom: solid 1px #CCC;

--- a/apps/bors_frontend/web/templates/project/settings.html.eex
+++ b/apps/bors_frontend/web/templates/project/settings.html.eex
@@ -16,9 +16,13 @@
 
 </nav>
 
-<main role=main><div class=wrapper>
+<main role=main>
 
+<div class=wrapper><section class=split>
+
+<section class=split-item>
 <h2 class=header>Reviewers</h2>
+<p>permission to run any command, and to change repository settings</p>
 <table class="table">
   <tbody>
 <%= for reviewer <- @reviewers do %>
@@ -29,7 +33,7 @@
       <%= form_for @conn, project_path(@conn, :remove_reviewer, @project.id, reviewer.id), [as: :reviewer, method: :delete], fn _ -> %>
       <td class="fill-link">
   <%= if reviewer.id != @current_user_id do %>
-          <%= submit "Remove", class: "table-button table-button--remove" %>
+          <%= submit "Remove", title: "Remove reviewer", class: "table-button table-button--remove" %>
   <% end %>
       </td>
       <% end %>
@@ -41,14 +45,49 @@
         <%= text_input f, :login, placeholder: "GitHub login" %>
       </td>
       <td class="fill-link table-button-col">
-        <%= submit "Add", class: "table-button table-button--add" %>
+        <%= submit "Add", title: "Add reviewer", class: "table-button table-button--add" %>
       </td>
       <% end %>
     </tr>
   </tbody>
 </table>
+</section> <!-- class=split-item -->
 
-<h2 class=header>Branches</h2>
+<section class=split-item>
+<h2 class=header>Members</h2>
+<p>permission to run "bors try", and, in the future, to run "bors retry"</p>
+<table class="table">
+  <tbody>
+<%= for member <- @members do %>
+    <tr role=row>
+      <td>
+        <%= member.login %>
+      </td>
+      <%= form_for @conn, project_path(@conn, :remove_member, @project.id, member.id), [as: :member, method: :delete], fn _ -> %>
+      <td class="fill-link">
+        <%= submit "Remove", title: "Remove member", class: "table-button table-button--remove" %>
+      </td>
+      <% end %>
+    </tr>
+<% end %>
+    <tr role=row>
+      <%= form_for @conn, project_path(@conn, :add_member, @project.id), [as: :member], fn f -> %>
+      <td>
+        <%= text_input f, :login, placeholder: "GitHub login" %>
+      </td>
+      <td class="fill-link table-button-col">
+        <%= submit "Add", title: "Add member", class: "table-button table-button--add" %>
+      </td>
+      <% end %>
+    </tr>
+  </tbody>
+</table>
+</section> <!-- class=split-item -->
+
+</section></div> <!-- class=split -->
+
+<div class=wrapper>
+  <h2 class=header>Branches</h2>
 <%= form_for @update_branches, project_path(@conn, :update_branches, @project), [as: :project], fn f -> %>
   <label for=staging_branch>staging</label>
   <%= text_input f, :staging_branch, id: "staging_branch" %>
@@ -56,5 +95,6 @@
   <%= text_input f, :trying_branch, id: "trying_branch" %>
   <div class=toolbar><%= submit "Update", class: "toolbar-item" %></div>
 <% end %>
+</div>
 
-</div></main>
+</main>


### PR DESCRIPTION
Part of #251 

Mere "members," as opposed to "reviewers," have permission to run "bors try" and will have permission to run "bors retry" once that's also implemented.