### PR TITLE
WIP: close PRs after merge

### DIFF
--- a/apps/bors_github/lib/github.ex
+++ b/apps/bors_github/lib/github.ex
@@ -42,6 +42,12 @@ defmodule BorsNG.GitHub do
     prs
   end
 
+  @spec close_pr(tconn, integer | bitstring) ::
+    {:ok} | {:error, term}
+  def close_pr(repo_conn, pr_xref) do
+    GenServer.call(BorsNG.GitHub, {:close_pr, repo_conn, {pr_xref}})
+  end
+
   @spec push!(tconn, binary, binary) :: binary
   def push!(repo_conn, sha, to) do
     {:ok, sha} = GenServer.call(BorsNG.GitHub, {:push, repo_conn, {sha, to}})

--- a/apps/bors_github/lib/github/server.ex
+++ b/apps/bors_github/lib/github/server.ex
@@ -87,6 +87,17 @@ defmodule BorsNG.GitHub.Server do
       [])}
   end
 
+  def do_handle_call(:close_pr, repo_conn, {pr_xref}) do
+    repo_conn
+    |> patch!("pulls/#{pr_xref}", Poison.encode!(%{"state": "closed"}))
+    |> case do
+      %{body: _, status_code: 200} ->
+        {:ok}
+      _ ->
+        {:error, :close_pr}
+    end
+  end
+
   def do_handle_call(:push, repo_conn, {sha, to}) do
     repo_conn
     |> patch!("git/refs/heads/#{to}", Poison.encode!(%{"sha": sha}))

--- a/apps/bors_worker/lib/batcher.ex
+++ b/apps/bors_worker/lib/batcher.ex
@@ -381,6 +381,7 @@ defmodule BorsNG.Worker.Batcher do
     |> Repo.all()
 
     send_message(repo_conn, patches, {:succeeded, statuses})
+    close_prs(repo_conn, patches)
   end
 
   defp complete_batch(:error, batch, statuses) do
@@ -553,6 +554,12 @@ defmodule BorsNG.Worker.Batcher do
       &1.commit,
       status,
       msg))
+  end
+
+  defp close_prs(repo_conn, patches) do
+    Enum.each(patches, &GitHub.close_pr!(
+      repo_conn,
+      &1.pr_xref))
   end
 
   @spec get_repo_conn(%Project{}) :: {{:installation, number}, number}


### PR DESCRIPTION
Currently GitHub automatically closes the PR, once it detects that
master has received the merge commit. So this operation should be a
noop and is mainly there to ensure the right behaviour from GitHub.

In the future this will be useful to guarantee PRs are getting closed
with different merging strategies that are not detected by GitHub.

---

This PR is still WIP. I currently don't see another way than closing the PRs manually after each batch if we want to support other merging strategies. This PR outlines the changes that I would make but it missing tests and mocking updates.

Any objections @notriddle?
  