### PR TITLE
Implement fixes for release-based container deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+_build
+deps

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+ARG ELIXIR_VERSION=1.4.5
+
+FROM elixir:${ELIXIR_VERSION} as builder
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
+RUN apt-get update -q && apt-get install -y build-essential libtool autoconf curl
+
+RUN DEBIAN_CODENAME=$(sed -n 's/VERSION=.*(\(.*\)).*/\1/p' /etc/os-release) && \
+    curl -q https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
+    echo "deb http://deb.nodesource.com/node_8.x $DEBIAN_CODENAME main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update -q && \
+    apt-get install -y nodejs
+
+RUN mix local.hex --force && \
+    mix local.rebar --force && \
+    mix hex.info
+
+
+WORKDIR /src
+ADD ./ /src/
+
+# Set default environment for building
+ENV ALLOW_PRIVATE_REPOS=true
+ENV MIX_ENV=prod
+
+RUN mix deps.get
+RUN cd /src/apps/bors_frontend && npm install && npm run deploy
+RUN mix phx.digest
+RUN mix release --env=$MIX_ENV
+
+####
+
+FROM debian:jessie-slim
+RUN apt-get update -q && apt-get install -y git-core libssl1.0.0 curl ca-certificates
+
+ENV DOCKERIZE_VERSION=v0.6.0
+RUN curl -Ls https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | \
+    tar xzv -C /usr/local/bin
+
+ADD ./docker-entrypoint /usr/local/bin/bors-ng-entrypoint
+COPY --from=builder /src/_build/prod/rel/ /app/
+
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+ENV PORT=4000
+ENV DATABASE_AUTO_MIGRATE=true
+ENV ALLOW_PRIVATE_REPOS=true
+
+WORKDIR /app
+ENTRYPOINT ["/usr/local/bin/bors-ng-entrypoint"]
+CMD ["./bors_frontend/bin/bors_frontend", "foreground"]
+
+EXPOSE 4000

--- a/README.md
+++ b/README.md
@@ -305,12 +305,14 @@ If you need more throughput than one dyno can provide, you should deploy using a
 
 ### Deploying using Docker (and compatible container orchestration systems)
 
-A Dockerfile is provided, which can be used to build a self-contained Bors-NG image with all the required assets.
+Pre-built Docker images are available at [Docker Hub](https://hub.docker.com/r/borsng/bors-ng/) for tags and the current `master` (as `bors-ng:latest`).
+
+The Dockerfile in the project root can be used to build the image yourself.
 It relies on [multi-stage builds](https://docs.docker.com/engine/userguide/eng-image/multistage-build/) as introduced in Docker 17.05,
 to generate a slim image without the Erlang, Elixir and NodeJS development tools.
 
 Most of the important configuration options should be set at runtime using environment variables, not unlike the Heroku instructions.
-All the same recommendations apply, with some extra nodes:
+All the same recommendations apply, with some extra notes:
 
 - `ELIXIR_VERSION` can be set as a build-time argument, and defaults to `1.4.5`
 - `ALLOW_PRIVATE_REPOS` must be set at both build and run times to take effect. It is set to ` true` by default.

--- a/apps/bors_database/config/prod.secret.exs
+++ b/apps/bors_database/config/prod.secret.exs
@@ -12,4 +12,5 @@ config :bors_database, BorsNG.Database.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: {:system, "DATABASE_URL"},
   pool_size: {:system, :integer, "POOL_SIZE", 10},
-  loggers:  loggers
+  loggers:  loggers,
+  ssl: {:system, :boolean, "DATABASE_USE_SSL", :true}

--- a/apps/bors_database/config/prod.secret.exs
+++ b/apps/bors_database/config/prod.secret.exs
@@ -12,5 +12,4 @@ config :bors_database, BorsNG.Database.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: {:system, "DATABASE_URL"},
   pool_size: {:system, :integer, "POOL_SIZE", 10},
-  ssl: true,
   loggers:  loggers

--- a/apps/bors_database/config/prod.secret.exs
+++ b/apps/bors_database/config/prod.secret.exs
@@ -13,4 +13,4 @@ config :bors_database, BorsNG.Database.Repo,
   url: {:system, "DATABASE_URL"},
   pool_size: {:system, :integer, "POOL_SIZE", 10},
   loggers:  loggers,
-  ssl: {:system, :boolean, "DATABASE_USE_SSL", :true}
+  ssl: {:system, :boolean, "DATABASE_USE_SSL", true}

--- a/apps/bors_database/lib/migrate.ex
+++ b/apps/bors_database/lib/migrate.ex
@@ -1,6 +1,12 @@
 defmodule BorsNG.Database.Migrate do
   def repos, do: Application.get_env(:bors_database, :ecto_repos, [])
 
+  def run_standalone do
+    up()
+
+    :init.stop()
+  end
+
   def up do
     {:ok, _} = Application.ensure_all_started(:bors_database, :permanent)
 
@@ -13,9 +19,6 @@ defmodule BorsNG.Database.Migrate do
           run_migrations_for(repo)
       end
     end
-
-    # Signal shutdown
-    :init.stop()
   end
 
   def create_storage_for(repo) do

--- a/apps/bors_database/lib/migrate.ex
+++ b/apps/bors_database/lib/migrate.ex
@@ -1,0 +1,61 @@
+defmodule BorsNG.Database.Migrate do
+  def repos, do: Application.get_env(:bors_database, :ecto_repos, [])
+
+  def up do
+    {:ok, _} = Application.ensure_all_started(:bors_database, :permanent)
+
+    Enum.each repos(), fn(repo) ->
+      case create_storage_for(repo) do
+        :seed ->
+          run_migrations_for(repo)
+          run_seeds_for(repo)
+        :migrate ->
+          run_migrations_for(repo)
+      end
+    end
+
+    # Signal shutdown
+    :init.stop()
+  end
+
+  def create_storage_for(repo) do
+    case repo.__adapter__.storage_up(repo.config) do
+      :ok -> :seed
+      {:error, :already_up} -> :migrate
+      {:error, term} when is_binary(term) ->
+        raise RuntimeError, "The database for #{inspect repo} couldn't be created: #{term}"
+      {:error, term} ->
+        raise RuntimeError, "The database for #{inspect repo} couldn't be created: #{inspect term}"
+    end
+  end
+
+  def run_migrations_for(repo) do
+    app = Keyword.get(repo.config, :otp_app)
+    IO.puts "Running migrations for #{app}"
+
+    Ecto.Migrator.run(repo, migrations_path(repo), :up, all: true)
+  end
+
+  def run_seeds_for(repo) do
+    seed_script = seeds_path(repo)
+
+    if File.exists?(seed_script) do
+      app = Keyword.get(repo.config, :otp_app)
+      IO.puts "Running seed script for #{app}"
+
+      Code.eval_file(seed_script)
+    end
+  end
+
+  def migrations_path(repo), do: priv_path_for(repo, "migrations")
+
+  def seeds_path(repo), do: priv_path_for(repo, "seeds.exs")
+
+  def priv_dir(app), do: "#{:code.priv_dir(app)}"
+
+  def priv_path_for(repo, filename) do
+    app = Keyword.get(repo.config, :otp_app)
+    repo_underscore = repo |> Module.split |> List.last |> Macro.underscore
+    Path.join([priv_dir(app), repo_underscore, filename])
+  end
+end

--- a/apps/bors_frontend/config/prod.secret.exs
+++ b/apps/bors_frontend/config/prod.secret.exs
@@ -4,7 +4,10 @@ config :bors_frontend, BorsNG.Endpoint,
   http: [port: {:system, "PORT"}],
   url: [host: {:system, "PUBLIC_HOST"}, scheme: "https", port: 443],
   check_origin: false,
-  cache_static_manifest: "priv/static/manifest.json",
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  server: true,
+  root: ".",
+  version: Application.spec(:myapp, :vsn),
   secret_key_base: {:system, "SECRET_KEY_BASE"}
 
 config :bors_frontend, BorsNG.WebhookParserPlug,

--- a/docker-entrypoint
+++ b/docker-entrypoint
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -ex
+
+db_addr="${DATABASE_URL##*@}"
+db_addr="${db_addr%%/*}"
+
+dockerize -wait "tcp://$db_addr" true
+exec "$@"

--- a/rel/commands/migrate
+++ b/rel/commands/migrate
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+$RELEASE_ROOT_DIR/bin/bors_frontend command Elixir.BorsNG.Database.Migrate run_standalone

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -45,4 +45,8 @@ release :bors_frontend do
   set applications: [
     bors_frontend: :permanent,
     bors_github: :permanent ]
+  set commands: [
+    "migrate": "rel/commands/migrate"
+  ]
+  set pre_start_hook: "rel/hooks/pre_start"
 end

--- a/rel/hooks/pre_start
+++ b/rel/hooks/pre_start
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+case "$DATABASE_AUTO_MIGRATE" in
+1|true|yes)
+    $RELEASE_ROOT_DIR/bin/bors_frontend migrate
+;;
+esac


### PR DESCRIPTION
Fix some configuration options that made production container deployments difficult, and add a custom module that can do the same job as `mix ecto.create` and `mix ecto.migrate`, as Mix tasks cannot be run from a compiled releases (based on the [sample code](https://github.com/bitwalker/distillery/blob/master/docs/Running%20Migrations.md) from the Distillery docs).