### PR TITLE
log: sort by update time

### DIFF
--- a/apps/bors_frontend/web/controllers/project_controller.ex
+++ b/apps/bors_frontend/web/controllers/project_controller.ex
@@ -105,7 +105,7 @@ defmodule BorsNG.ProjectController do
     end)
     crashes = Repo.all(Crash.all_for_project(project.id))
     entries = crashes ++ batches
-    |> Enum.sort_by(fn %{inserted_at: at} -> Date.to_erl(at) end)
+    |> Enum.sort_by(fn %{updated_at: at} -> Date.to_erl(at) end)
     |> Enum.reverse()
     render conn, "log.html",
       project: project,


### PR DESCRIPTION
the logs where originally sorted by create time but displayed by update
time which was confusing