### PR TITLE
docker: Install inotify-tools in the docker image

### DIFF
--- a/script/Dockerfile
+++ b/script/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /tmp/dockerfile
 RUN echo "deb http://deb.nodesource.com/node_6.x jessie main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-key add nodesource.gpg.key && \
     apt-get update && \
-    apt-get install -y nodejs build-essential libtool autoconf git
+    apt-get install -y nodejs build-essential libtool autoconf git inotify-tools
 WORKDIR /srv
 RUN mix local.hex --force && mix local.rebar --force
 CMD mix phoenix.server


### PR DESCRIPTION
This gets rid of an error I saw from phoenix_live_reload when running
the tests:

    [error] backend port not found: :inotifywait