### PR TITLE
database: Use custom Ecto types for state columns

### DIFF
--- a/apps/bors_database/lib/attempt.ex
+++ b/apps/bors_database/lib/attempt.ex
@@ -7,12 +7,13 @@ defmodule BorsNG.Database.Attempt do
   """
 
   use BorsNG.Database.Model
+  alias BorsNG.Database.AttemptState
 
   schema "attempts" do
     belongs_to :patch, Patch
     field :into_branch, :string
     field :commit, :string
-    field :state, :integer
+    field :state, AttemptState
     field :last_polled, :integer
     field :timeout_at, :integer
     timestamps()
@@ -26,26 +27,6 @@ defmodule BorsNG.Database.Attempt do
       state: 0,
       last_polled: DateTime.to_unix(DateTime.utc_now(), :seconds)
     }
-  end
-
-  def atomize_state(state) do
-    case state do
-      0 -> :waiting
-      1 -> :running
-      2 -> :ok
-      3 -> :error
-      4 -> :canceled
-    end
-  end
-
-  def numberize_state(st) do
-    case st do
-      :waiting -> 0
-      :running -> 1
-      :ok -> 2
-      :error -> 3
-      :canceled -> 4
-    end
   end
 
   def all(:incomplete) do
@@ -77,7 +58,6 @@ defmodule BorsNG.Database.Attempt do
   end
 
   def all_for_patch(patch_id, state) do
-    state = Attempt.numberize_state(state)
     from b in all_for_patch(patch_id),
       where: b.state == ^state
   end

--- a/apps/bors_database/lib/attempt_state.ex
+++ b/apps/bors_database/lib/attempt_state.ex
@@ -1,0 +1,60 @@
+defmodule BorsNG.Database.AttemptState do
+  @behaviour Ecto.Type
+  @moduledoc """
+  A type to represent the attmept state.
+  """
+
+  # Underlying storage is an integer.
+  def type, do: :integer
+
+  # Accept the integer state values for easier translation of existing code.
+  def cast(state) when is_integer(state) do
+    case state do
+      0 -> {:ok, :waiting}
+      1 -> {:ok, :running}
+      2 -> {:ok, :ok}
+      3 -> {:ok, :error}
+      4 -> {:ok, :canceled}
+      _ -> :error
+    end
+  end
+
+  def cast(state) when is_atom(state) do
+    case state do
+      :waiting  -> {:ok, :waiting}
+      :running  -> {:ok, :running}
+      :ok       -> {:ok, :ok}
+      :error    -> {:ok, :error}
+      :canceled -> {:ok, :canceled}
+      _        -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  def load(int) when is_integer(int) do
+    cast(int)
+  end
+
+  def dump(term) when is_atom(term) do
+    case term do
+      :waiting  -> {:ok, 0}
+      :running  -> {:ok, 1}
+      :ok       -> {:ok, 2}
+      :error    -> {:ok, 3}
+      :canceled -> {:ok, 4}
+      _        -> :error
+    end
+  end
+
+  def dump(term) when is_integer(term) do
+    case term do
+      0 -> {:ok, 0}
+      1 -> {:ok, 1}
+      2 -> {:ok, 2}
+      3 -> {:ok, 3}
+      4 -> {:ok, 4}
+      _ -> :error
+    end
+  end
+end

--- a/apps/bors_database/lib/attempt_status.ex
+++ b/apps/bors_database/lib/attempt_status.ex
@@ -9,12 +9,13 @@ defmodule BorsNG.Database.AttemptStatus do
   """
 
   use BorsNG.Database.Model
+  alias BorsNG.Database.AttemptStatusState
 
   schema "attempt_statuses" do
     belongs_to :attempt, Attempt
     field :identifier, :string
     field :url, :string
-    field :state, :integer
+    field :state, AttemptStatusState
     timestamps()
   end
 
@@ -40,27 +41,8 @@ defmodule BorsNG.Database.AttemptStatus do
   end
 
   def all_for_attempt(attempt_id, state) do
-    state = AttemptStatus.numberize_state(state)
     from s in AttemptStatus,
       where: s.attempt_id == ^attempt_id,
       where: s.state == ^state
-  end
-
-  def atomize_state(state) do
-    case state do
-      0 -> :waiting
-      1 -> :running
-      2 -> :ok
-      3 -> :error
-    end
-  end
-
-  def numberize_state(state) do
-    case state do
-      :waiting -> 0
-      :running -> 1
-      :ok -> 2
-      :error -> 3
-    end
   end
 end

--- a/apps/bors_database/lib/attempt_status_state.ex
+++ b/apps/bors_database/lib/attempt_status_state.ex
@@ -1,0 +1,56 @@
+defmodule BorsNG.Database.AttemptStatusState do
+  @behaviour Ecto.Type
+  @moduledoc """
+  A type to represent the status state.
+  """
+
+  # Underlying storage is an integer.
+  def type, do: :integer
+
+  # Accept the integer state values for easier translation of existing code.
+  def cast(state) when is_integer(state) do
+    case state do
+      0 -> {:ok, :waiting}
+      1 -> {:ok, :running}
+      2 -> {:ok, :ok}
+      3 -> {:ok, :error}
+      _ -> :error
+    end
+  end
+
+  def cast(state) when is_atom(state) do
+    case state do
+      :waiting -> {:ok, :waiting}
+      :running -> {:ok, :running}
+      :ok      -> {:ok, :ok}
+      :error   -> {:ok, :error}
+      _        -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  def load(int) when is_integer(int) do
+    cast(int)
+  end
+
+  def dump(term) when is_atom(term) do
+    case term do
+      :waiting -> {:ok, 0}
+      :running -> {:ok, 1}
+      :ok      -> {:ok, 2}
+      :error   -> {:ok, 3}
+      _        -> :error
+    end
+  end
+
+  def dump(term) when is_integer(term) do
+    case term do
+      0 -> {:ok, 0}
+      1 -> {:ok, 1}
+      2 -> {:ok, 2}
+      3 -> {:ok, 3}
+      _ -> :error
+    end
+  end
+end

--- a/apps/bors_database/lib/batch_state.ex
+++ b/apps/bors_database/lib/batch_state.ex
@@ -1,0 +1,72 @@
+defmodule BorsNG.Database.BatchState do
+  @behaviour Ecto.Type
+  @moduledoc """
+  A type to represent the batch state.
+  """
+
+  # Underlying storage is an integer.
+  def type, do: :integer
+
+  # Accept the integer state values for easier translation of existing code.
+  def cast(state) when is_integer(state) do
+    case state do
+      0 -> {:ok, :waiting}
+      1 -> {:ok, :running}
+      2 -> {:ok, :ok}
+      3 -> {:ok, :error}
+      4 -> {:ok, :canceled}
+      _ -> :error
+    end
+  end
+
+  def cast(state) when is_atom(state) do
+    case state do
+      :waiting  -> {:ok, :waiting}
+      :running  -> {:ok, :running}
+      :ok       -> {:ok, :ok}
+      :error    -> {:ok, :error}
+      :canceled -> {:ok, :canceled}
+      _         -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  def load(int) when is_integer(int) do
+    cast(int)
+  end
+
+  def dump(term) when is_atom(term) do
+    case term do
+      :waiting  -> {:ok, 0}
+      :running  -> {:ok, 1}
+      :ok       -> {:ok, 2}
+      :error    -> {:ok, 3}
+      :conflict -> {:ok, 3}
+      :canceled -> {:ok, 4}
+      _ -> :error
+    end
+  end
+
+  def dump(term) when is_integer(term) do
+    case term do
+      0 -> {:ok, 0}
+      1 -> {:ok, 1}
+      2 -> {:ok, 2}
+      3 -> {:ok, 3}
+      4 -> {:ok, 4}
+      _ -> :error
+    end
+  end
+
+  def numberize(st) do
+    case st do
+      :waiting -> 0
+      :running -> 1
+      :ok -> 2
+      :error -> 3
+      :conflict -> 3
+      :canceled -> 4
+    end
+  end
+end

--- a/apps/bors_database/lib/patch.ex
+++ b/apps/bors_database/lib/patch.ex
@@ -49,11 +49,9 @@ defmodule BorsNG.Database.Patch do
   end
 
   defp all_links_not_err do
-    err = Batch.numberize_state(:error)
-    canceled = Batch.numberize_state(:canceled)
     from l in LinkPatchBatch,
       join: b in Batch,
-      on: l.batch_id == b.id and b.state != ^err and b.state != ^canceled
+      on: l.batch_id == b.id and b.state != ^:error and b.state != ^:canceled
   end
 
   def all(:awaiting_review) do

--- a/apps/bors_database/lib/status.ex
+++ b/apps/bors_database/lib/status.ex
@@ -9,12 +9,13 @@ defmodule BorsNG.Database.Status do
   @type state :: :waiting | :running | :ok | :error
 
   use BorsNG.Database.Model
+  alias BorsNG.Database.StatusState
 
   schema "statuses" do
     belongs_to :batch, Batch
     field :identifier, :string
     field :url, :string
-    field :state, :integer
+    field :state, StatusState
     timestamps()
   end
 
@@ -40,29 +41,8 @@ defmodule BorsNG.Database.Status do
   end
 
   def all_for_batch(batch_id, state) do
-    state = Status.numberize_state(state)
     from s in Status,
       where: s.batch_id == ^batch_id,
       where: s.state == ^state
-  end
-
-  @spec atomize_state(state_n) :: state
-  def atomize_state(state) do
-    case state do
-      0 -> :waiting
-      1 -> :running
-      2 -> :ok
-      3 -> :error
-    end
-  end
-
-  @spec numberize_state(state) :: state_n
-  def numberize_state(state) do
-    case state do
-      :waiting -> 0
-      :running -> 1
-      :ok -> 2
-      :error -> 3
-    end
   end
 end

--- a/apps/bors_database/lib/status_state.ex
+++ b/apps/bors_database/lib/status_state.ex
@@ -1,0 +1,56 @@
+defmodule BorsNG.Database.StatusState do
+  @behaviour Ecto.Type
+  @moduledoc """
+  A type to represent the status state.
+  """
+
+  # Underlying storage is an integer.
+  def type, do: :integer
+
+  # Accept the integer state values for easier translation of existing code.
+  def cast(state) when is_integer(state) do
+    case state do
+      0 -> {:ok, :waiting}
+      1 -> {:ok, :running}
+      2 -> {:ok, :ok}
+      3 -> {:ok, :error}
+      _ -> :error
+    end
+  end
+
+  def cast(state) when is_atom(state) do
+    case state do
+      :waiting -> {:ok, :waiting}
+      :running -> {:ok, :running}
+      :ok      -> {:ok, :ok}
+      :error   -> {:ok, :error}
+      _        -> :error
+    end
+  end
+
+  def cast(_), do: :error
+
+  def load(int) when is_integer(int) do
+    cast(int)
+  end
+
+  def dump(term) when is_atom(term) do
+    case term do
+      :waiting -> {:ok, 0}
+      :running -> {:ok, 1}
+      :ok      -> {:ok, 2}
+      :error   -> {:ok, 3}
+      _        -> :error
+    end
+  end
+
+  def dump(term) when is_integer(term) do
+    case term do
+      0 -> {:ok, 0}
+      1 -> {:ok, 1}
+      2 -> {:ok, 2}
+      3 -> {:ok, 3}
+      _ -> :error
+    end
+  end
+end

--- a/apps/bors_database/test/models/batch_test.exs
+++ b/apps/bors_database/test/models/batch_test.exs
@@ -63,11 +63,11 @@ defmodule BorsNG.Database.BatchTest do
 
   test "compute next poll time" do
     p = %Project{batch_delay_sec: 1, batch_poll_period_sec: 2}
-    b = %Batch{project: p, last_polled: 3, state: 0}
+    b = %Batch{project: p, last_polled: 3, state: :waiting}
     assert Batch.get_next_poll_unix_sec(b) == 4
     assert Batch.next_poll_is_past(b, 5)
     refute Batch.next_poll_is_past(b, 3)
-    b = %Batch{b | state: 1}
+    b = %Batch{b | state: :running}
     assert Batch.get_next_poll_unix_sec(b) == 5
     assert Batch.next_poll_is_past(b, 6)
     refute Batch.next_poll_is_past(b, 3)

--- a/apps/bors_frontend/test/controllers/project_controller_test.exs
+++ b/apps/bors_frontend/test/controllers/project_controller_test.exs
@@ -69,7 +69,11 @@ defmodule BorsNG.ProjectControllerTest do
 
   test "show a batched patch", %{conn: conn, project: project, user: user} do
     conn = login conn
-    batch = Repo.insert! %Batch{project_id: project.id, commit: "BC", state: 0}
+    batch = Repo.insert! %Batch{
+      project_id: project.id,
+      commit: "BC",
+      state: :waiting
+    }
     patch = Repo.insert! %Patch{project_id: project.id, commit: "PC"}
     Repo.insert! %LinkPatchBatch{patch_id: patch.id, batch_id: batch.id}
     Repo.insert! %LinkUserProject{user_id: user.id, project_id: project.id}

--- a/apps/bors_frontend/web/views/project_view.ex
+++ b/apps/bors_frontend/web/views/project_view.ex
@@ -12,12 +12,12 @@ defmodule BorsNG.ProjectView do
 
   def stringify_state(state) do
     case state do
-      0 -> "Waiting to run"
-      1 -> "Running"
-      2 -> "Succeeded"
-      3 -> "Failed"
-      4 -> "Canceled"
-      _ -> "Invalid"
+      :waiting  -> "Waiting to run"
+      :running  -> "Running"
+      :ok       -> "Succeeded"
+      :error    -> "Failed"
+      :canceled -> "Canceled"
+      _         -> "Invalid"
     end
   end
 

--- a/apps/bors_worker/lib/batcher/state.ex
+++ b/apps/bors_worker/lib/batcher/state.ex
@@ -12,7 +12,6 @@ defmodule BorsNG.Worker.Batcher.State do
   def summary_database_statuses(statuses) do
     statuses
     |> Enum.map(&(&1.state))
-    |> Enum.map(&BorsNG.Database.Status.atomize_state/1)
     |> summary_states()
   end
 

--- a/apps/bors_worker/test/attemptor_test.exs
+++ b/apps/bors_worker/test/attemptor_test.exs
@@ -181,7 +181,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }}
     attempt = Repo.get_by! Attempt, patch_id: patch.id
-    assert attempt.state == 1
+    assert attempt.state == :running
     # Polling should not change that.
     Attemptor.handle_info(:poll, proj.id)
     assert GitHub.ServerMock.get_state() == %{
@@ -194,7 +194,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }}
     attempt = Repo.get_by! Attempt, patch_id: patch.id
-    assert attempt.state == 1
+    assert attempt.state == :running
     # Mark the CI as having finished.
     # At this point, just running should still do nothing.
     GitHub.ServerMock.put_state(%{
@@ -208,7 +208,7 @@ defmodule BorsNG.Worker.AttemptorTest do
       }})
     Attemptor.handle_info(:poll, proj.id)
     attempt = Repo.get_by! Attempt, patch_id: patch.id
-    assert attempt.state == 1
+    assert attempt.state == :running
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{
@@ -224,7 +224,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     |> Repo.update!()
     Attemptor.handle_info(:poll, proj.id)
     attempt = Repo.get_by! Attempt, patch_id: patch.id
-    assert attempt.state == 2
+    assert attempt.state == :ok
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{


### PR DESCRIPTION
This commit introduces custom Ecto types for the state columns in the
`attempts`, `attempt_statuses`, `batches`, and `statuses` tables.  This
allows use of atoms throughout the codebase without have to go through
the `atomize_state` `numberize_state` dance.