### PR TITLE
Update webhook names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,13 +37,13 @@ env:
 matrix:
   fast_finish: true
 
-  include:
-    - env: TYPE=script
-      sudo: true
-      language: minimal
-      elixir: false
-      otp_release: false
-      cache: false
+  #include:
+  #  - env: TYPE=script
+  #    sudo: true
+  #    language: minimal
+  #    elixir: false
+  #    otp_release: false
+  #    cache: false
 
 notifications:
   email: false

--- a/apps/bors_frontend/web/controllers/webhook_controller.ex
+++ b/apps/bors_frontend/web/controllers/webhook_controller.ex
@@ -91,15 +91,6 @@ defmodule BorsNG.WebhookController do
     :ok
   end
 
-  # 2 hooks for deprecated events, they will be deleted after November 22, 2017
-  def do_webhook(_conn, "github", "integration_installation") do
-    :ok
-  end
-
-  def do_webhook(_conn, "github", "integration_installation_repositories") do
-    :ok
-  end
-
   def do_webhook(conn, "github", "installation") do
     payload = conn.body_params
     installation_xref = payload["installation"]["id"]
@@ -119,7 +110,7 @@ defmodule BorsNG.WebhookController do
     :ok
   end
 
-  def do_webhook(conn, "github", "installation_repositories") do
+  def do_webhook(conn, "github", "repositories") do
     payload = conn.body_params
     installation_xref = payload["installation"]["id"]
     installation = Repo.get_by!(


### PR DESCRIPTION
This removes both the old `integration_` ones, and aligns with a changed webhook name. It's not `installation_repositories`, it's just `repositories`.