### PR TITLE
older postgrex not compatible with Heroku 10.2 postgres

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -40,6 +40,7 @@ defmodule BorsNg.Mixfile do
       {:ex_doc, "~> 0.14", only: :dev},
       {:credo, "~> 0.7", only: [:dev, :test]},
       {:confex, "~> 3.3.1"},
+      {:postgrex, "~> 0.13.5"},
     ]
   end
 end


### PR DESCRIPTION
Heroku upgraded our database to 10.2.  It looks like the old version of `postgrex` (an upstream dependency, I believe) does not work with the new database:  https://github.com/elixir-ecto/postgrex/issues/370

```
2018-02-16 20:45:09.466 127 <190>1 2018-02-16T20:45:09.276450+00:00 app web.1 - - ** (ArgumentError) argument error
2018-02-16 20:45:09.467 183 <190>1 2018-02-16T20:45:09.276452+00:00 app web.1 - -     (postgrex) lib/postgrex/utils.ex:67: anonymous fn/1 in Postgrex.Utils.parse_version/1
2018-02-16 20:45:09.467 155 <190>1 2018-02-16T20:45:09.276454+00:00 app web.1 - -     (elixir) lib/enum.ex:1229: Enum."-map/2-lists^map/1-0-"/2
2018-02-16 20:45:09.467 155 <190>1 2018-02-16T20:45:09.276456+00:00 app web.1 - -     (elixir) lib/enum.ex:1229: Enum."-map/2-lists^map/1-0-"/2
2018-02-16 20:45:09.467 165 <190>1 2018-02-16T20:45:09.276457+00:00 app web.1 - -     (postgrex) lib/postgrex/utils.ex:67: Postgrex.Utils.parse_version/1
2018-02-16 20:45:09.467 173 <190>1 2018-02-16T20:45:09.276459+00:00 app web.1 - -     (postgrex) lib/postgrex/protocol.ex:641: Postgrex.Protocol.bootstrap_send/6
2018-02-16 20:45:09.467 168 <190>1 2018-02-16T20:45:09.276460+00:00 app web.1 - -     (postgrex) lib/postgrex/protocol.ex:475: Postgrex.Protocol.handshake/2
2018-02-16 20:45:09.467 184 <190>1 2018-02-16T20:45:09.276462+00:00 app web.1 - -     (db_connection) lib/db_connection/connection.ex:134: DBConnection.Connection.connect/2
2018-02-16 20:45:09.467 160 <190>1 2018-02-16T20:45:09.276464+00:00 app web.1 - -     (connection) lib/connection.ex:622: Connection.enter_connect/5
```