### PR TITLE
Link to the specific batch ID in commit statuses

### DIFF
--- a/lib/web/static/css/app.css
+++ b/lib/web/static/css/app.css
@@ -214,6 +214,9 @@ footer {
 .table col td:not([role="presentation"]) {
   background: #EEE;
 }
+.table tr:target {
+  background: #EEE;
+}
 .table tbody tr[role="row"]:hover {
   background: #EEE;
 }
@@ -287,7 +290,7 @@ footer {
   box-shadow: 0 1px 2px #666;
   cursor: pointer;
 }
-.toolbar-item:hover, 
+.toolbar-item:hover,
 .toolbar-item:focus {
   text-decoration: none;
   box-shadow: 0 1px 4px #666;

--- a/lib/web/templates/project/log.html.eex
+++ b/lib/web/templates/project/log.html.eex
@@ -21,14 +21,16 @@
 <table class="table">
   <tbody>
 <%= for entry <- @entries do %>
-    <tr role=row>
   <%= case entry do %>
-    <% %BorsNG.Database.Crash{component: component, crash: crash, updated_at: updated_at} -> %>
+  <% %BorsNG.Database.Crash{component: component, crash: crash, updated_at: updated_at} -> %>
+    <tr role=row>
       <td><%= htmlify_naive_datetime(updated_at) %></td>
       <td>Crash</td>
       <td><%= component %></td>
       <td><pre><code><%= crash %></code></pre></td>
-    <% %BorsNG.Database.Batch{state: state, patches: patches, updated_at: updated_at} -> %>
+    </tr>
+  <% %BorsNG.Database.Batch{id: id, state: state, patches: patches, updated_at: updated_at} -> %>
+    <tr role=row id=batch-<%= id %>>
       <td><%= htmlify_naive_datetime(updated_at) %></td>
       <td>Batch</td>
       <td><%= stringify_state(state) %></td>
@@ -39,8 +41,8 @@
         </a>
       <% end %>
       </td>
-  <% end %>
     </tr>
+  <% end %>
 <% end %>
   </tbody>
 </table>


### PR DESCRIPTION
 - Add batch IDs log rows
 - Set the background color on `<tr>`s targeted via the URL fragment
 - Clean up some trailing whitespace
 - Append the batch ID to send_status