### PR TITLE
Add backend support for automatic reviewer/member assignment per-repository

### DIFF
--- a/lib/database/model.ex
+++ b/lib/database/model.ex
@@ -27,6 +27,7 @@ defmodule BorsNG.Database.Model do
       alias BorsNG.Database.Crash
       alias BorsNG.Database.Installation
       alias BorsNG.Database.LinkPatchBatch
+      alias BorsNG.Database.LinkMemberProject
       alias BorsNG.Database.LinkUserProject
       alias BorsNG.Database.Patch
       alias BorsNG.Database.Project

--- a/lib/database/project.ex
+++ b/lib/database/project.ex
@@ -6,6 +6,7 @@ defmodule BorsNG.Database.Project do
   """
 
   use BorsNG.Database.Model
+  alias BorsNG.Database.ProjectPermission
 
   @type t :: %Project{}
 
@@ -24,12 +25,17 @@ defmodule BorsNG.Database.Project do
     belongs_to :installation, Installation
     field :repo_xref, :integer
     field :name, :string
-    many_to_many :users, User, join_through: LinkUserProject
+    many_to_many :users, User, join_through: LinkUserProject,
+                 on_replace: :delete
+    many_to_many :members, User, join_through: LinkMemberProject,
+                 on_replace: :delete
     field :staging_branch, :string, default: "staging"
     field :trying_branch, :string, default: "trying"
     field :batch_poll_period_sec, :integer, default: (60 * 30)
     field :batch_delay_sec, :integer, default: 10
     field :batch_timeout_sec, :integer, default: (60 * 60 * 2)
+    field :auto_reviewer_required_perm, ProjectPermission, default: :admin
+    field :auto_member_required_perm, ProjectPermission, default: nil
 
     timestamps()
   end
@@ -63,7 +69,8 @@ defmodule BorsNG.Database.Project do
   """
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:repo_xref, :name])
+    |> cast(params, [:repo_xref, :name, :auto_reviewer_required_perm,
+                     :auto_member_required_perm])
   end
   def changeset_branches(struct, params \\ %{}) do
     struct

--- a/lib/database/project_permission.ex
+++ b/lib/database/project_permission.ex
@@ -1,0 +1,28 @@
+defmodule BorsNG.Database.ProjectPermission do
+  @behaviour Ecto.Type
+  @moduledoc """
+  A type to represent the permissions of a project member.
+  """
+
+  def type, do: :string
+
+  def cast(data) when data in ["admin", "push", "pull"] do
+    {:ok, String.to_atom(data)}
+  end
+
+  def cast(data) when data in [:admin, :push, :pull] do
+    {:ok, data}
+  end
+
+  def cast(_), do: :error
+
+  def load(data) do
+    cast(data)
+  end
+
+  def dump(data) when data in [:admin, :push, :pull] do
+    {:ok, Atom.to_string(data)}
+  end
+
+  def dump(_), do: :error
+end

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -21,6 +21,9 @@ defmodule BorsNG.GitHub do
   @type trepo :: BorsNG.GitHub.Repo.t
   @type tpr :: BorsNG.GitHub.Pr.t
   @type tstatus :: :ok | :running | :error
+  @type trepo_perm :: :admin | :push | :pull
+  @type tuser_repo_perms :: %{admin: boolean, push: boolean, pull: boolean}
+  @type tcollaborator :: %{user: tuser, perms: tuser_repo_perms}
 
   @spec get_pr!(tconn, integer | bitstring) :: BorsNG.GitHub.Pr.t
   def get_pr!(repo_conn, pr_xref) do
@@ -145,11 +148,12 @@ defmodule BorsNG.GitHub do
     user
   end
 
-  @spec get_admins_by_repo(tconn) :: {:ok, [tuser]} | :error
-  def get_admins_by_repo(repo_conn) do
+  @spec get_collaborators_by_repo(tconn) ::
+    {:ok, [tcollaborator]} | :error
+  def get_collaborators_by_repo(repo_conn) do
     GenServer.call(
       BorsNG.GitHub,
-      {:get_admins_by_repo, repo_conn, {}})
+      {:get_collaborators_by_repo, repo_conn, {}})
   end
 
   @spec get_app!() :: String.t()

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -67,6 +67,7 @@ defmodule BorsNG.GitHub.ServerMock do
   @type ttoken :: BorsNG.GitHub.ttoken
   @type trepo :: BorsNG.GitHub.trepo
   @type tuser :: BorsNG.GitHub.User.t
+  @type tcollaborator :: BorsNG.GitHub.tcollaborator
 
   @type tbranch :: bitstring
   @type tcommit :: bitstring
@@ -76,7 +77,8 @@ defmodule BorsNG.GitHub.ServerMock do
       branches: %{tbranch => tcommit},
       comments: %{integer => [bitstring]},
       statuses: %{tbranch => %{bitstring => :open | :closed | :running}},
-      files: %{tbranch => %{bitstring => bitstring}}
+      files: %{tbranch => %{bitstring => bitstring}},
+      collaborators: [tcollaborator]
     },
     {:installation, number} => %{
       repos: [trepo]
@@ -316,8 +318,14 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
-  def do_handle_call(:get_admins_by_repo, _repo_conn, {}, state) do
-    {{:ok, []}, state}
+  def do_handle_call(:get_collaborators_by_repo, repo_conn, {}, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn),
+         {:ok, users} <- Map.fetch(repo, :collaborators) do
+      {{:ok, users}, state}
+    else
+      _ ->
+        {{:error, :get_collaborators_by_repo}, state}
+    end
   end
 
   def do_handle_call(

--- a/priv/repo/migrations/20180304194919_add_auto_reviewer_required_perm_to_project.exs
+++ b/priv/repo/migrations/20180304194919_add_auto_reviewer_required_perm_to_project.exs
@@ -1,0 +1,10 @@
+defmodule BorsNG.Database.Repo.Migrations.
+          AddAutoReviewerRequiredPermToProject do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :auto_reviewer_required_perm, :string, null: true, default: "admin"
+    end
+  end
+end

--- a/priv/repo/migrations/20180304201200_add_auto_member_required_perm_to_project.exs
+++ b/priv/repo/migrations/20180304201200_add_auto_member_required_perm_to_project.exs
@@ -1,0 +1,9 @@
+defmodule BorsNG.Database.Repo.Migrations.AddAutoMemberRequiredPermToProject do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      add :auto_member_required_perm, :string, null: true, default: nil
+    end
+  end
+end

--- a/test/models/project_test.exs
+++ b/test/models/project_test.exs
@@ -62,4 +62,43 @@ defmodule BorsNG.Database.ProjectTest do
     [project_x] = Repo.all(Project.by_owner(user.id))
     assert project_x.id == project.id
   end
+
+  test "accept valid permission values", %{installation: installation} do
+    {result, _} = Repo.insert(%Project{
+      installation_id: installation.id,
+      repo_xref: 13,
+      name: "example/project",
+      auto_reviewer_required_perm: :admin,
+      auto_member_required_perm: :admin})
+    assert result == :ok
+
+    {result, _} = Repo.insert(%Project{
+      installation_id: installation.id,
+      repo_xref: 14,
+      name: "example/project2",
+      auto_reviewer_required_perm: :push,
+      auto_member_required_perm: :pull})
+    assert result == :ok
+  end
+
+  test "accept nil permission values", %{installation: installation} do
+    {result, _} = Repo.insert(%Project{
+      installation_id: installation.id,
+      repo_xref: 13,
+      name: "example/project",
+      auto_reviewer_required_perm: nil,
+      auto_member_required_perm: nil})
+    assert result == :ok
+  end
+
+  test "reject invalid permission values", %{installation: installation} do
+    assert_raise Ecto.ChangeError, fn ->
+      Repo.insert!(%Project{
+        installation_id: installation.id,
+        repo_xref: 13,
+        name: "example/project",
+        auto_reviewer_required_perm: :invalid,
+        auto_member_required_perm: :invalid})
+    end
+  end
 end

--- a/test/syncer_test.exs
+++ b/test/syncer_test.exs
@@ -1,3 +1,6 @@
+import Ecto
+import Ecto.Query
+
 defmodule BorsNG.Worker.SyncerTest do
   use BorsNG.Worker.TestCase
 
@@ -16,12 +19,15 @@ defmodule BorsNG.Worker.SyncerTest do
       repo_xref: 14,
       staging_branch: "staging"}
     |> Repo.insert!()
-    {:ok, inst: inst, proj: proj}
+    {:ok,
+     inst: inst,
+     proj: proj,
+     proj_conn: {{:installation, inst.installation_xref}, proj.repo_xref}}
   end
 
-  test "add and open patches", %{proj: proj} do
+  test "add and open patches", %{proj: proj, proj_conn: proj_conn} do
     GitHub.ServerMock.put_state(%{
-      {{:installation, 91}, 14} => %{
+      proj_conn => %{
         pulls: %{
           1 => %GitHub.Pr{
             number: 1,
@@ -49,7 +55,8 @@ defmodule BorsNG.Worker.SyncerTest do
               avatar_url: "whatevs",
             }
           }
-        }
+        },
+        collaborators: []
       }})
     Repo.insert! %Patch{
       project_id: proj.id,
@@ -66,9 +73,9 @@ defmodule BorsNG.Worker.SyncerTest do
     assert p2.open
   end
 
-  test "close a patch", %{proj: proj} do
+  test "close a patch", %{proj: proj, proj_conn: proj_conn} do
     GitHub.ServerMock.put_state(%{
-      {{:installation, 91}, 14} => %{
+      proj_conn => %{
         pulls: %{
           1 => %GitHub.Pr{
             number: 1,
@@ -96,7 +103,8 @@ defmodule BorsNG.Worker.SyncerTest do
               avatar_url: "whatevs",
             }
           }
-        }
+        },
+        collaborators: []
       }})
     %Patch{
       project_id: proj.id,
@@ -114,9 +122,9 @@ defmodule BorsNG.Worker.SyncerTest do
     assert p2.open
   end
 
-  test "update commit on changed patch", %{proj: proj} do
+  test "update commit on changed patch", %{proj: proj, proj_conn: proj_conn} do
     GitHub.ServerMock.put_state(%{
-      {{:installation, 91}, 14} => %{
+      proj_conn => %{
         pulls: %{
           1 => %GitHub.Pr{
             number: 1,
@@ -132,6 +140,7 @@ defmodule BorsNG.Worker.SyncerTest do
             },
           },
         },
+        collaborators: []
       }})
     Repo.insert! %Patch{
       project_id: proj.id,
@@ -144,5 +153,60 @@ defmodule BorsNG.Worker.SyncerTest do
     p1 = Repo.get_by! Patch, pr_xref: 1, project_id: proj.id
     assert p1.commit == "B"
     assert p1.open
+  end
+
+  test "synchronize collaborators with correct permissions",
+    %{proj: proj, proj_conn: proj_conn}
+  do
+    # Set up some Github users with different permissions and previous existence
+    # state
+    old_admin =      %GitHub.User{id: 1, login: "existing-admin"}
+    new_admin =      %GitHub.User{id: 2, login: "new-admin"}
+    removed_admin =  %GitHub.User{id: 3, login: "removed-admin"}
+    old_pusher =     %GitHub.User{id: 4, login: "existing-pusher"}
+    new_pusher =     %GitHub.User{id: 5, login: "new-pusher"}
+    removed_pusher = %GitHub.User{id: 6, login: "removed-pusher"}
+    puller =         %GitHub.User{id: 7, login: "puller"}
+
+    # Create the users that should exist
+    saved_admins = [old_admin, removed_admin]
+    |> Enum.map(&Syncer.sync_user/1)
+
+    saved_pushers = [old_pusher, removed_pusher]
+    |> Enum.map(&Syncer.sync_user/1)
+
+    # Set up the pre-existing associations and settings
+    proj = proj
+    |> Repo.preload([:users, :members])
+    |> Ecto.Changeset.change(%{auto_reviewer_required_perm: :admin,
+                               auto_member_required_perm: :push})
+    |> Ecto.Changeset.put_assoc(:users, saved_admins)
+    |> Ecto.Changeset.put_assoc(:members, saved_pushers)
+    |> Repo.update!()
+
+    # Set up the Github response
+    GitHub.ServerMock.put_state(%{
+      proj_conn => %{
+        collaborators: [
+          %{user: old_admin, perms: %{admin: true, push: true, pull: true}},
+          %{user: new_admin, perms: %{admin: true, push: true, pull: true}},
+          # removed admin is not present
+          %{user: old_pusher, perms: %{admin: false, push: true, pull: true}},
+          %{user: new_pusher, perms: %{admin: false, push: true, pull: true}},
+          # removed pusher is not present
+          %{user: puller, perms: %{admin: false, push: false, pull: true}}
+        ]
+      }})
+
+    :ok = Syncer.synchronize_project_collaborators(proj_conn, proj.id)
+
+    user_xrefs = Repo.all(from u in assoc(proj, :users),
+                          select: u.user_xref)
+    member_xrefs = Repo.all(from u in assoc(proj, :members),
+                            select: u.user_xref)
+
+    assert Enum.sort(user_xrefs) == Enum.sort([old_admin.id, new_admin.id])
+    assert Enum.sort(member_xrefs) == Enum.sort([old_admin.id, new_admin.id,
+                                                 old_pusher.id, new_pusher.id])
   end
 end


### PR DESCRIPTION
Instead of just synchronizing repository admins as reviewers, add a
per-project setting indicating which kind of GitHub collaborators
automatically become reviewers or members. Additionally, remove any
user which no longer has the required permissions from the corresponding
user set.

The possible values for the `auto_reviewer_required_perm` and
`auto_member_required_perm` are `admin`, `push` and `pull`, matching the
GitHub permission model, or `nil`, indicating that no automatic
synchronization should be performed.

This will make it easier to manage large repositories/organizations with
many collaborators without requiring manual handling for each repository.

User interface changes exposing those settings to users will be added at
a later pull-request.