### PR TITLE
Do not synchronize reviewers by default

### DIFF
--- a/lib/worker/syncer.ex
+++ b/lib/worker/syncer.ex
@@ -37,7 +37,7 @@ defmodule BorsNG.Worker.Syncer do
   end
 
   @spec synchronize_project_collaborators_by_role(
-    Project.t, [tcollaborator], :users | :members, trepo_perm) ::
+    Project.t, [tcollaborator], :users | :members, trepo_perm | nil) ::
     {:ok, Project.t} | {:error, any()}
   def synchronize_project_collaborators_by_role(project, collaborators,
                                                 association, github_perm)

--- a/priv/repo/migrations/20180315212108_do_not_sync_users_by_default.exs
+++ b/priv/repo/migrations/20180315212108_do_not_sync_users_by_default.exs
@@ -1,0 +1,10 @@
+defmodule BorsNG.Database.Repo.Migrations.DoNotSyncUsersByDefault do
+  use Ecto.Migration
+
+  def change do
+    alter table(:projects) do
+      remove :auto_reviewer_required_perm
+      add :auto_reviewer_required_perm, :string, null: true, default: nil
+    end
+  end
+end


### PR DESCRIPTION
This can be reverted when the GUI for #360 is implemented.

Fixes #368