### PR TITLE
Ignore invalid pull requests when doing a sync

### DIFF
--- a/lib/github/github/pr.ex
+++ b/lib/github/github/pr.ex
@@ -93,7 +93,7 @@ defmodule BorsNG.GitHub.Pr do
     }}
   end
 
-  def from_json(_) do
-    :error
+  def from_json(x) do
+    {:error, x}
   end
 end

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -338,7 +338,12 @@ defmodule BorsNG.GitHub.Server do
       [{"Authorization", "token #{token}"}, {"Accept", @content_type}],
       [params: params])
     prs = Poison.decode!(raw)
-    |> Enum.map(&BorsNG.GitHub.Pr.from_json!/1)
+    |> Enum.flat_map(fn element ->
+      element |> BorsNG.GitHub.Pr.from_json |> case do
+        {:ok, pr} -> [pr]
+        _ -> []
+      end
+    end)
     |> Enum.concat(append)
     next_headers = get_next_headers(headers)
     case next_headers do


### PR DESCRIPTION
It might be possible to make bors work when a pull request is opened against a fork, and then the fork gets deleted without the PR getting closed, but that seems like such a weird corner case...

But here it is happening: https://forum.bors.tech/t/bors-is-not-syncing/155

In any case, one broken PR shouldn't prevent all the other ones from syncing.