### PR TITLE
Enable custom dashboard header & footer

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -37,6 +37,9 @@ config :bors, BorsNG,
           <a class=header-link href="https://forum.bors.tech">Forum</a>
           <a class=header-link href="https://bors.tech/documentation/getting-started/">Docs</a>
           <b class=header-link>Dashboard</b>
+    """},
+  dashboard_footer_html: {:system, :string, "DASHBOARD_FOOTER_HTML", """
+        This service is provided for free on a best-effort basis.
     """}
 
 # Configures the endpoint

--- a/config/config.exs
+++ b/config/config.exs
@@ -31,7 +31,13 @@ config :bors,
 config :bors, BorsNG,
   command_trigger: "bors",
   home_url: "https://bors.tech/",
-  allow_private_repos: {:system, :boolean, "ALLOW_PRIVATE_REPOS", false}
+  allow_private_repos: {:system, :boolean, "ALLOW_PRIVATE_REPOS", false},
+  dashboard_header_html: {:system, :string, "DASHBOARD_HEADER_HTML", """
+          <a class=header-link href="https://bors.tech">Home</a>
+          <a class=header-link href="https://forum.bors.tech">Forum</a>
+          <a class=header-link href="https://bors.tech/documentation/getting-started/">Docs</a>
+          <b class=header-link>Dashboard</b>
+    """}
 
 # Configures the endpoint
 config :bors, BorsNG.Endpoint,

--- a/config/dogma.exs
+++ b/config/dogma.exs
@@ -5,6 +5,10 @@ config :dogma,
 
   # Select a set of rules as a base
   rule_set: Dogma.RuleSet.All,
+  
+  exclude: [
+    ~r(\Aconfig/)
+  ],
 
   # Override an existing rule configuration
   override: [

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -40,10 +40,7 @@
       <div class="wrapper wrapper--mini">
         <a id=header-logo href="<%= page_path(@conn, :index) %>"><img alt="bors" src='<%= static_path(@conn, "/images/a.svg") %>' width="90" height="25"></a>
         <span id=header-sections class=hide-on-narrow>
-          <a class=header-link href="https://bors.tech">Home</a>
-          <a class=header-link href="https://forum.bors.tech">Forum</a>
-          <a class=header-link href="https://bors.tech/documentation/getting-started/">Docs</a>
-          <b class=header-link>Dashboard</b>
+          <%= {:safe, get_header_html()} %>
         </span>
         <span id=header-user>
 <%= if is_nil @conn.assigns[:user] do %>

--- a/lib/web/templates/layout/app.html.eex
+++ b/lib/web/templates/layout/app.html.eex
@@ -87,7 +87,7 @@
             <%= elem(get_version(), 0) %>
           </a>
         </span>
-        This service is provided for free on a best-effort basis.
+        <%= {:safe, get_footer_html()} %>
       </p>
     </footer>
 

--- a/lib/web/views/layout_view.ex
+++ b/lib/web/views/layout_view.ex
@@ -53,4 +53,8 @@ defmodule BorsNG.LayoutView do
   def get_header_html do
     Confex.fetch_env!(:bors, BorsNG)[:dashboard_header_html]
   end
+
+  def get_footer_html do
+    Confex.fetch_env!(:bors, BorsNG)[:dashboard_footer_html]
+  end
 end

--- a/lib/web/views/layout_view.ex
+++ b/lib/web/views/layout_view.ex
@@ -49,4 +49,8 @@ defmodule BorsNG.LayoutView do
       _ -> nil
     end
   end
+
+  def get_header_html do
+    Confex.fetch_env!(:bors, BorsNG)[:dashboard_header_html]
+  end
 end


### PR DESCRIPTION
These changes allow a user to set `DASHBOARD_HEADER_HTML` and `DASHBOARD_FOOTER_HTML` to customize the dashboard.

Fixes #376 #377 

One question I had was about the proper indentation for the default values.  As it is they're just verbatim moved from the template file, but I could see reformatting them.

(My first Elixir change ever!  Figured this would be a good way to get started contributing here, before diving into some of the more involved issues I've got my eye on.)