### PR TITLE
Sort patches before creating merge commit

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -243,6 +243,7 @@ defmodule BorsNG.Worker.Batcher do
     project = batch.project
     repo_conn = get_repo_conn(project)
     patch_links = Repo.all(LinkPatchBatch.from_batch(batch.id))
+    |> Enum.sort_by(&(&1.patch.pr_xref))
     stmp = "#{project.staging_branch}.tmp"
     base = GitHub.get_branch!(
       repo_conn,

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -84,7 +84,6 @@ defmodule BorsNG.Worker.Batcher.Message do
   end
 
   def generate_commit_message(patch_links, cut_body_after) do
-    patch_links = Enum.sort_by(patch_links, &(&1.patch.pr_xref))
     commit_title = Enum.reduce(patch_links,
       "Merge", &"#{&2} \##{&1.patch.pr_xref}")
     commit_body = Enum.reduce(patch_links, "", fn link, acc ->

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -40,6 +40,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         files: %{}
@@ -51,6 +52,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => ["## try\n\nNot awaiting review"]
           },
@@ -63,6 +65,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{".travis.yml" => ""}}
@@ -77,6 +80,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{".travis.yml" => "", "appveyor.yml" => ""}}
@@ -94,6 +98,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"circle.yml" => ""}}
@@ -108,6 +113,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"jet-steps.yml" => ""}}
@@ -122,6 +128,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"jet-steps.json" => ""}}
@@ -136,6 +143,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"codeship-steps.yml" => ""}}
@@ -150,6 +158,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"codeship-steps.json" => ""}}
@@ -165,6 +174,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -176,6 +186,9 @@ defmodule BorsNG.Worker.AttemptorTest do
         branches: %{
           "master" => "ini",
           "trying" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -189,6 +202,9 @@ defmodule BorsNG.Worker.AttemptorTest do
         branches: %{
           "master" => "ini",
           "trying" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -202,6 +218,9 @@ defmodule BorsNG.Worker.AttemptorTest do
         branches: %{
           "master" => "ini",
           "trying" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => [{"ci", :ok}]},
         files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -214,6 +233,9 @@ defmodule BorsNG.Worker.AttemptorTest do
         branches: %{
           "master" => "ini",
           "trying" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => [{"ci", :ok}]},
         files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -230,6 +252,9 @@ defmodule BorsNG.Worker.AttemptorTest do
         branches: %{
           "master" => "ini",
           "trying" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => ["## try\n\n# Build succeeded\n  * ci"]},
         statuses: %{"iniN" => [{"ci", :ok}]},
         files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -240,6 +265,7 @@ defmodule BorsNG.Worker.AttemptorTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"trying" => %{"circle.yml" => ""}}

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -55,6 +55,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{},
         files: %{}
@@ -85,6 +86,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => ["# Canceled"],
           2 => []
@@ -100,6 +102,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         files: %{}
@@ -121,6 +124,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => ["# Canceled"]
           },
@@ -134,6 +138,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{},
         files: %{}
@@ -170,6 +175,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => ["# Canceled"],
           2 => ["# Canceled (will resume)"]},
@@ -187,6 +193,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         files: %{}
@@ -201,6 +208,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         files: %{}
@@ -211,6 +219,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         files: %{}
@@ -231,6 +240,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => ["Not awaiting review"]
           },
@@ -243,6 +253,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         labels: %{1 => ["no"]},
         statuses: %{"Z" => %{}},
@@ -260,6 +271,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => [":-1: Rejected by label"]},
         labels: %{1 => ["no"]},
@@ -273,6 +285,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"Z" => %{"cn" => :error}},
         files: %{"Z" => %{"bors.toml" =>
@@ -289,6 +302,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => [":-1: Rejected by PR status"]},
         statuses: %{"Z" => %{"bors" => :error, "cn" => :error}},
@@ -301,6 +315,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"Z" => %{"cn" => :ok}},
         reviews: %{1 => %{"APPROVED" => 0, "CHANGES_REQUESTED" => 1}},
@@ -318,6 +333,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => [":-1: Rejected by code reviews"]},
         statuses: %{"Z" => %{"bors" => :error, "cn" => :ok}},
@@ -331,6 +347,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"Z" => %{"cn" => :ok}},
         reviews: %{1 => %{"APPROVED" => 0, "CHANGES_REQUESTED" => 0}},
@@ -352,6 +369,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => [":-1: Rejected by too few approved reviews"]},
         statuses: %{"Z" => %{"bors" => :error, "cn" => :ok}},
@@ -369,6 +387,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"Z" => %{"cn" => :ok}},
         reviews: %{1 => %{"APPROVED" => 1, "CHANGES_REQUESTED" => 0}},
@@ -390,6 +409,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert state == %{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{
           1 => []},
         statuses: %{"Z" => %{"bors" => :running, "cn" => :ok}},
@@ -408,6 +428,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         files: %{}
@@ -422,6 +443,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"N" => %{"bors" => :running}},
         files: %{}
@@ -444,6 +466,10 @@ defmodule BorsNG.Worker.BatcherTest do
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini",
           "staging" => ""},
+        commits: %{
+          "ini" => %{
+            commit_message: "[ci skip]",
+            parents: ["ini"]}},
         comments: %{1 => ["# Configuration problem\nbors.toml: not found"]},
         statuses: %{"N" => %{"bors" => :error}},
         files: %{}
@@ -455,6 +481,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => %{}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -469,6 +496,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => %{}, "N" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -492,6 +520,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => %{}, "N" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -512,6 +545,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => %{}, "N" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -523,6 +561,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{
           "iniN" => %{"ci" => :ok},
@@ -537,6 +580,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{
           "iniN" => %{"ci" => :ok},
@@ -555,6 +603,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "iniN",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => ["# Build succeeded\n  * ci"]},
         statuses: %{
           "iniN" => %{"bors" => :ok, "ci" => :ok},
@@ -568,6 +621,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -588,6 +642,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{"N" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -607,6 +662,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => [], 2 => []},
         statuses: %{"N" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -618,6 +678,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => [], 2 => []},
         statuses: %{
           "N" => %{"bors" => :running},
@@ -645,6 +710,12 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "iniN",
           "staging" => "iniNO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{commit_message: "[ci skip]", parents: ["iniN"]},
+          "iniNO" => %{
+            commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["iniN", "O"]}},
         comments: %{1 => ["# Build succeeded\n  * ci"], 2 => []},
         statuses: %{
           "iniN" => %{"bors" => :ok},
@@ -659,6 +730,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -679,6 +751,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{"N" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -698,6 +771,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => [], 2 => []},
         statuses: %{"N" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -725,6 +803,14 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "iniO" => %{
+            commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "O"]}},
         comments: %{1 => [], 2 => []},
         statuses: %{
           "iniN" => %{"bors" => :running},
@@ -741,6 +827,14 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "iniO",
           "staging" => "iniO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "iniO" => %{
+            commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "O"]}},
         comments: %{2 => ["# Build succeeded\n  * ci"], 1 => []},
         statuses: %{
           "iniN" => %{"bors" => :running},
@@ -762,6 +856,15 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "iniO",
           "staging" => "iniON"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "iniO" => %{commit_message: "[ci skip]", parents: ["iniO"]},
+          "iniON" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["iniO", "N"]}},
         comments: %{2 => ["# Build succeeded\n  * ci"], 1 => []},
         statuses: %{
           "iniN" => %{"bors" => :running},
@@ -779,6 +882,15 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "iniON",
           "staging" => "iniON"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "iniO" => %{commit_message: "[ci skip]", parents: ["iniO"]},
+          "iniON" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["iniO", "N"]}},
         comments: %{
           2 => ["# Build succeeded\n  * ci"],
           1 => ["# Build succeeded\n  * ci"]},
@@ -797,6 +909,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -818,6 +931,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{"N" => %{"bors" => :running}, "O" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -837,6 +951,12 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniNO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]}},
         comments: %{1 => [], 2 => []},
         statuses: %{"N" => %{"bors" => :running}, "O" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -851,6 +971,12 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniNO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]}},
         comments: %{
           1 => ["# Build failed (retrying...)\n  * ci"],
           2 => ["# Build failed (retrying...)\n  * ci"]},
@@ -874,6 +1000,15 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{
           1 => ["# Build failed (retrying...)\n  * ci"],
           2 => ["# Build failed (retrying...)\n  * ci"]},
@@ -894,6 +1029,15 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{
           1 => [
             "# Build failed\n  * ci",
@@ -918,6 +1062,18 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "iniO" => %{
+            commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "O"]}},
         comments: %{
           1 => [
             "# Build failed\n  * ci",
@@ -941,6 +1097,18 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "iniO" => %{
+            commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "O"]}},
         comments: %{
           1 => [
             "# Build failed\n  * ci",
@@ -965,6 +1133,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -986,6 +1155,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{
           "N" => %{"bors" => :running},
@@ -1008,6 +1178,11 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{1 => [], 2 => []},
         statuses: %{
           "N" => %{"bors" => :running},
@@ -1038,6 +1213,15 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "iniN",
           "staging" => "releaseO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "release" => %{commit_message: "[ci skip]", parents: ["release"]},
+          "releaseO" => %{
+            commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["release", "O"]}},
         comments: %{1 => ["# Build succeeded\n  * ci"], 2 => []},
         statuses: %{
           "iniN" => %{"bors" => :ok},
@@ -1052,6 +1236,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -1073,6 +1258,7 @@ defmodule BorsNG.Worker.BatcherTest do
     assert GitHub.ServerMock.get_state() == %{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => [], 2 => []},
         statuses: %{"N" => %{"bors" => :running}, "O" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -1092,6 +1278,12 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniNO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]}},
         comments: %{1 => [], 2 => []},
         statuses: %{"N" => %{"bors" => :running}, "O" => %{"bors" => :running}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
@@ -1109,6 +1301,12 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniNO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]}},
         comments: %{
           1 => ["# Timed out (retrying...)"],
           2 => ["# Timed out (retrying...)"]},
@@ -1132,6 +1330,15 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{
           1 => ["# Timed out (retrying...)"],
           2 => ["# Timed out (retrying...)"]},
@@ -1155,6 +1362,15 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniN"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]}},
         comments: %{
           1 => ["# Timed out", "# Timed out (retrying...)"],
           2 => ["# Timed out (retrying...)"]},
@@ -1177,6 +1393,18 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "iniO" => %{
+            commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "O"]}},
         comments: %{
           1 => ["# Timed out", "# Timed out (retrying...)"],
           2 => ["# Timed out (retrying...)"]},
@@ -1201,6 +1429,18 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{
           "master" => "ini",
           "staging" => "iniO"},
+        commits: %{
+          "ini" => %{commit_message: "[ci skip]", parents: ["ini"]},
+          "iniNO" => %{
+            commit_message: "Merge #1 #2\n\n1:  r=rvr a=[unknown]\n\n\n" <>
+              "\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N", "O"]},
+          "iniN" => %{
+            commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "N"]},
+          "iniO" => %{
+            commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n",
+            parents: ["ini", "O"]}},
         comments: %{
           1 => ["# Timed out", "# Timed out (retrying...)"],
           2 => ["# Timed out", "# Timed out (retrying...)"]},
@@ -1220,6 +1460,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"staging.tmp" => %{".travis.yml" => ""}}
@@ -1246,6 +1487,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
         files: %{"staging.tmp" =>
@@ -1273,6 +1515,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         files: %{}
@@ -1291,6 +1534,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         files: %{}
@@ -1363,6 +1607,7 @@ defmodule BorsNG.Worker.BatcherTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => %{}},
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -76,25 +76,8 @@ defmodule BorsNG.Worker.BatcherMessageTest do
           body: "b",
           author: %{login: "leg"}},
         reviewer: "s"}]
-    patches2 = [
-      %{
-        patch: %{
-          pr_xref: 2,
-          title: "Beta",
-          body: "b",
-          author: %{login: "leg"}},
-        reviewer: "s"},
-      %{
-        patch: %{
-          pr_xref: 1,
-          title: "Alpha",
-          body: "a",
-          author: %{login: "lag"}},
-        reviewer: "r"}]
     actual_message = Message.generate_commit_message(patches, nil)
     assert expected_message == actual_message
-    actual_message2 = Message.generate_commit_message(patches2, nil)
-    assert expected_message == actual_message2
   end
 
   test "cut body" do

--- a/test/branch_deleter_test.exs
+++ b/test/branch_deleter_test.exs
@@ -25,6 +25,7 @@ defmodule BorsNG.Worker.BranchDeleterTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "update" => "foo"},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         pulls: %{
@@ -77,6 +78,7 @@ defmodule BorsNG.Worker.BranchDeleterTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "update" => "foo"},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         pulls: %{
@@ -131,6 +133,7 @@ defmodule BorsNG.Worker.BranchDeleterTest do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
         branches: %{"master" => "ini", "update" => "foo"},
+        commits: %{},
         comments: %{1 => []},
         statuses: %{},
         pulls: %{


### PR DESCRIPTION
Previously, only the commit message was sorted, but not the
commit parents.  This moves the sort earlier, so that all
processing on the batch happens in the same sorted order.

Fixes: #391 

I removed the previous test that the commit message generation sorted the PRs, since it's no longer valid.  I'd like to add a test that the sorting is still being done, but I'm not really sure where to put it.  The tests in `test/batcher/batcher_test.ex` don't seem to have a clear way to assert on the generated commit.  Perhaps some extensions to `lib/github/github/server_mock.ex` would help?  (This also affects my changes in #392 fwiw...)