### PR TITLE
Sort log by time as well as date

### DIFF
--- a/lib/web/controllers/project_controller.ex
+++ b/lib/web/controllers/project_controller.ex
@@ -105,7 +105,7 @@ defmodule BorsNG.ProjectController do
     end)
     crashes = Repo.all(Crash.all_for_project(project.id))
     entries = crashes ++ batches
-    |> Enum.sort_by(fn %{updated_at: at} -> Date.to_erl(at) end)
+    |> Enum.sort_by(fn %{updated_at: at} -> NaiveDateTime.to_iso8601(at) end)
     |> Enum.reverse()
     render conn, "log.html",
       project: project,


### PR DESCRIPTION
Previously, the log was sorted by date, but not by time
within a given date.  This corrects that issue.

Fixes: #374