### PR TITLE
Enable committer name & e-mail configuration

### DIFF
--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -24,6 +24,7 @@ defmodule BorsNG.GitHub do
   @type trepo_perm :: :admin | :push | :pull
   @type tuser_repo_perms :: %{admin: boolean, push: boolean, pull: boolean}
   @type tcollaborator :: %{user: tuser, perms: tuser_repo_perms}
+  @type tcommitter :: %{name: bitstring, email: bitstring}
 
   @spec get_pr!(tconn, integer | bitstring) :: BorsNG.GitHub.Pr.t
   def get_pr!(repo_conn, pr_xref) do
@@ -83,7 +84,8 @@ defmodule BorsNG.GitHub do
     branch: bitstring,
     tree: bitstring,
     parents: [bitstring],
-    commit_message: bitstring}) :: binary
+    commit_message: bitstring,
+    committer: tcommitter}) :: binary
   def synthesize_commit!(repo_conn, info) do
     {:ok, sha} = GenServer.call(
       BorsNG.GitHub,

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -147,8 +147,15 @@ defmodule BorsNG.GitHub.Server do
     branch: branch,
     tree: tree,
     parents: parents,
-    commit_message: commit_message}}) do
+    commit_message: commit_message,
+    committer: committer}}) do
     msg = %{"parents": parents, "tree": tree, "message": commit_message}
+    msg = if is_nil committer do
+      msg
+    else
+      Map.put(msg, "author", %{
+        "name": committer.name, "email": committer.email})
+    end
     repo_conn
     |> post!("git/commits", Poison.encode!(msg))
     |> case do

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -222,7 +222,8 @@ defmodule BorsNG.GitHub.ServerMock do
     branch: branch,
     tree: tree,
     parents: parents,
-    commit_message: commit_message}}, state) do
+    commit_message: commit_message,
+    committer: _committer}}, state) do
     with {:ok, repo} <- Map.fetch(state, repo_conn),
          {:ok, branches} <- Map.fetch(repo, :branches),
          {:ok, commits} <- Map.fetch(repo, :commits) do

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -254,7 +254,8 @@ defmodule BorsNG.Worker.Batcher do
         branch: stmp,
         tree: base.tree,
         parents: [base.commit],
-        commit_message: "[ci skip]"})
+        commit_message: "[ci skip]",
+        committer: nil})
     do_merge_patch = fn %{patch: patch}, branch ->
       case branch do
         :conflict -> :conflict
@@ -299,7 +300,8 @@ defmodule BorsNG.Worker.Batcher do
             branch: batch.project.staging_branch,
             tree: tree,
             parents: parents,
-            commit_message: commit_message})
+            commit_message: commit_message,
+            committer: toml.committer})
         setup_statuses(batch, toml)
         {:running, head}
       {:error, message} ->

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -68,7 +68,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{".travis.yml" => ""}}
+        files: %{"trying.tmp" => %{".travis.yml" => ""}}
       }})
     patch = new_patch(proj, 1, "N")
     Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
@@ -83,7 +83,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{".travis.yml" => "", "appveyor.yml" => ""}}
+        files: %{"trying.tmp" => %{".travis.yml" => "", "appveyor.yml" => ""}}
       }})
     patch = new_patch(proj, 1, "N")
     Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
@@ -101,7 +101,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"circle.yml" => ""}}
+        files: %{"trying.tmp" => %{"circle.yml" => ""}}
       }})
     patch = new_patch(proj, 1, "N")
     Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
@@ -116,7 +116,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"jet-steps.yml" => ""}}
+        files: %{"trying.tmp" => %{"jet-steps.yml" => ""}}
       }})
     patch = new_patch(proj, 1, "N")
     Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
@@ -131,7 +131,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"jet-steps.json" => ""}}
+        files: %{"trying.tmp" => %{"jet-steps.json" => ""}}
       }})
     patch = new_patch(proj, 1, "N")
     Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
@@ -146,7 +146,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"codeship-steps.yml" => ""}}
+        files: %{"trying.tmp" => %{"codeship-steps.yml" => ""}}
       }})
     patch = new_patch(proj, 1, "N")
     Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
@@ -161,7 +161,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"codeship-steps.json" => ""}}
+        files: %{"trying.tmp" => %{"codeship-steps.json" => ""}}
       }})
     patch = new_patch(proj, 1, "N")
     Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
@@ -177,7 +177,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
+        files: %{"trying.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }})
     patch = new_patch(proj, 1, "N")
     Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
@@ -191,7 +191,7 @@ defmodule BorsNG.Worker.AttemptorTest do
           "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
+        files: %{"trying.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }}
     attempt = Repo.get_by! Attempt, patch_id: patch.id
     assert attempt.state == :running
@@ -207,7 +207,7 @@ defmodule BorsNG.Worker.AttemptorTest do
           "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
+        files: %{"trying.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }}
     attempt = Repo.get_by! Attempt, patch_id: patch.id
     assert attempt.state == :running
@@ -223,7 +223,7 @@ defmodule BorsNG.Worker.AttemptorTest do
           "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => [{"ci", :ok}]},
-        files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
+        files: %{"trying.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }})
     Attemptor.handle_info(:poll, proj.id)
     attempt = Repo.get_by! Attempt, patch_id: patch.id
@@ -238,7 +238,7 @@ defmodule BorsNG.Worker.AttemptorTest do
           "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => []},
         statuses: %{"iniN" => [{"ci", :ok}]},
-        files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
+        files: %{"trying.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }}
     # Finally, an actual poll should finish it.
     attempt
@@ -257,7 +257,7 @@ defmodule BorsNG.Worker.AttemptorTest do
           "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
         comments: %{1 => ["## try\n\n# Build succeeded\n  * ci"]},
         statuses: %{"iniN" => [{"ci", :ok}]},
-        files: %{"trying" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
+        files: %{"trying.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }}
   end
 
@@ -268,7 +268,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => []},
-        files: %{"trying" => %{"circle.yml" => ""}}
+        files: %{"trying.tmp" => %{"circle.yml" => ""}}
       }})
     patch = %Patch{
       project_id: proj.id,

--- a/test/batcher/bors_toml_test.exs
+++ b/test/batcher/bors_toml_test.exs
@@ -44,6 +44,19 @@ defmodule BatcherBorsTomlTest do
     assert toml.timeout_sec == 2
   end
 
+  test "can parse committer details" do
+    {:ok, toml} = BorsToml.new(
+      ~s/status = ["exl"]\n[committer]\nname = "BORS"\nemail = "bors@ex.com"/)
+    assert toml.committer.name == "BORS"
+    assert toml.committer.email == "bors@ex.com"
+  end
+
+  test "defaults committer details to nil" do
+    {:ok, toml} = BorsToml.new(
+      ~s/status = ["exl"]/)
+    assert is_nil toml.committer
+  end
+
   test "defaults cut_body_after to nil" do
     {:ok, toml} = BorsToml.new(~s/status = ["exl"]/)
     assert is_nil toml.cut_body_after
@@ -67,5 +80,15 @@ defmodule BatcherBorsTomlTest do
   test "recognizes an invalid cut_body_after" do
     r = BorsToml.new(~s/cut_body_after = 13/)
     assert r == {:error, :cut_body_after}
+  end
+
+  test "requires committer email if name provided" do
+    r = BorsToml.new(~s/status = ["exl"]\n[committer]\nname = "BORS!"/)
+    assert r == {:error, :committer_details}
+  end
+
+  test "requires committer name if email provided" do
+    r = BorsToml.new(~s/status = ["exl"]\n[committer]\nemail = "bors@ex.com"/)
+    assert r == {:error, :committer_details}
   end
 end


### PR DESCRIPTION
This change adds a table to the bors.toml file to configure
the committer details for Bors merge commits. By adding a
committer table with name and email keys, the commits
created on GitHub will show up as authored by that user.

Fixes: #343
Fixes: #381 

Example:

    [committer]
    name = "Andrew Couch"
    email = "couchand@noreply.github.com"
