### PR TITLE
Prevent unwanted space after queue log PR links

### DIFF
--- a/lib/web/templates/project/log.html.eex
+++ b/lib/web/templates/project/log.html.eex
@@ -36,9 +36,7 @@
       <td><%= stringify_state(state) %></td>
       <td>
       <%= for patch <- patches do %>
-        <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">
-          #<%= patch.pr_xref %>
-        </a>
+        <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
       <% end %>
       </td>
     </tr>


### PR DESCRIPTION
Right now the spaces in between PR links in the log are also links, because there's extra whitespace in the `a` tag here. If we remove that extra whitespace in the `a` tag, then we should still have a space between links because of the indentation before the `a` tag giving us our needed whitespace, but it won't be inside the `a` tag so it won't be part of the link.

This makes the line pretty long; it could also maybe be formatted as e.g.:
```
<a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%=
  patch.pr_xref
%></a>
```