### PR TITLE
allow customizing the command trigger

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -29,7 +29,7 @@ config :bors,
 
 # General application configuration
 config :bors, BorsNG,
-  command_trigger: "bors",
+  command_trigger: {:system, :string, "COMMAND_TRIGGER", "bors"},
   home_url: "https://bors.tech/",
   allow_private_repos: {:system, :boolean, "ALLOW_PRIVATE_REPOS", false},
   dashboard_header_html: {:system, :string, "DASHBOARD_HEADER_HTML", """


### PR DESCRIPTION
This allows self-hosted copies of bors to choose their own command trigger. For example, this will allow us to silently replace our aging Homu mergebot with a bors-ng mergebot, without having to retrain all our contributors to use a different name.