### PR TITLE
Isolate syncs between installations

### DIFF
--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -88,6 +88,7 @@ defmodule BorsNG.WebhookController do
     :ok
   end
 
+  def do_webhook(conn, "github", "repository"), do: do_webhook_installation_sync(conn)
   def do_webhook(conn, "github", "member"), do: do_webhook_installation_sync(conn)
   def do_webhook(conn, "github", "membership"), do: do_webhook_installation_sync(conn)
   def do_webhook(conn, "github", "team"), do: do_webhook_installation_sync(conn)

--- a/lib/worker/syncer_installation.ex
+++ b/lib/worker/syncer_installation.ex
@@ -32,7 +32,8 @@ defmodule BorsNG.Worker.SyncerInstallation do
     GitHub.get_installation_list!()
     |> Enum.each(fn installation_xref ->
       {worker, worker_monitor} = spawn_monitor fn ->
-        synchronize_installation(installation_xref)
+        synchronize_installation(%Installation{
+                                installation_xref: installation_xref})
       end
       receive do
         {:DOWN, ^worker_monitor, _, _, _} -> :ok


### PR DESCRIPTION
This particular case was brought on by a repository that was added to bors-ng and blocked by GitHub for ToS violation. Since this doesn't automatically remove the repo from the installation, bors would find the repository there, then fail to synchronize it.