### PR TITLE
Update to a newer heroku stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "Bors-NG",
   "description": "A merge bot for GitHub pull requests",
   "repository": "https://github.com/bors-ng/bors-ng",
-  "website": "https://bors-ng.github.io/",
+  "website": "https://bors.tech/",
   "logo": "https://cdn.rawgit.com/bors-ng/bors-ng/b9e756ecfdf4ede9241a8a30cbfdc4c010fd0a22/icon/bors-eye.svg",
   "keywords": ["github", "continuous-integration", "continuous-testing", "elixir", "phoenix"],
 

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,5 +1,5 @@
 clean_cache=false
 compile="compile"
 config_vars_to_export=(ALLOW_PRIVATE_REPOS SCOUT_KEY SCOUT_LOG_LEVEL SCOUT_MONITOR)
-node_version=5.3.0
+node_version=8.12.0
 phoenix_relative_path=.


### PR DESCRIPTION
This is useful to pull in the new version of brunch, which requires a newer version of node, and the newer distillery also requires a newer version of elixir.