### PR TITLE
Keep GitHub App configuration up-to-date

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,8 @@ For each of these sections, set the following overall section permissions and ch
   - *Organization* ( User invited to, added to, or removed from an organization)
 - *Organization projects*: No access
 - *Checks*: Read & Write
-  - *Check run* (CheckSuite created from the API)
+  - *Check run* (Check run created from the API)
+  - *Check suite* (Check suite created from the API)
 
 #### Permission explanations
 


### PR DESCRIPTION
This commit keeps `Check run` and `Check suite` separated in the GitHub app configuration instructions, as they currently are in GitHub web UI:

![screenshot_2018-10-02 build software better together](https://user-images.githubusercontent.com/1447321/46335434-b3f4f700-c627-11e8-9496-9ffa92c0e5e2.png)

PS: `check_suite` is apparently [silently ignored](https://github.com/bors-ng/bors-ng/blob/2102420ec646b5c149f2466fba08066984a510e6/lib/web/controllers/webhook_controller.ex#L197-L199) but since the code expects it, it makes sense to me to configure it in the GitHub App permissions. Please let me know if I'm wrong.
