### PR TITLE
Avoid assuming that commits are unique by project

### DIFF
--- a/lib/database/attempt.ex
+++ b/lib/database/attempt.ex
@@ -62,9 +62,9 @@ defmodule BorsNG.Database.Attempt do
       where: b.state == ^state
   end
 
-  def get_by_commit(commit, state) do
+  def get_by_commit(project_id, commit, state) do
     from b in all(state),
-      where: b.commit == ^commit
+      where: b.commit == ^commit and b.project_id == ^project_id
   end
 
   def next_poll_is_past(attempt, project) do

--- a/lib/database/batch.ex
+++ b/lib/database/batch.ex
@@ -88,9 +88,9 @@ defmodule BorsNG.Database.Batch do
         or b.state == ^(:canceled)
   end
 
-  def get_assoc_by_commit(commit, state \\ nil) do
+  def get_assoc_by_commit(project_id, commit, state \\ nil) do
     from b in all_assoc(state),
-      where: b.commit == ^commit
+      where: b.commit == ^commit and b.project_id == ^project_id
   end
 
   def next_poll_is_past(batch) do

--- a/lib/worker/attemptor.ex
+++ b/lib/worker/attemptor.ex
@@ -82,8 +82,10 @@ defmodule BorsNG.Worker.Attemptor do
   end
 
   def do_handle_cast({:status, {commit, identifier, state, url}}, project_id) do
-    attempt = Repo.all(Attempt.get_by_commit(commit, :incomplete))
-    case attempt do
+    project_id
+    |> Attempt.get_by_commit(commit, :incomplete)
+    |> Repo.all()
+    |> case do
       [attempt] ->
         patch = Repo.get!(Patch, attempt.patch_id)
         ^project_id = patch.project_id

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -131,10 +131,12 @@ defmodule BorsNG.Worker.Batcher do
   end
 
   def do_handle_cast({:status, {commit, identifier, state, url}}, project_id) do
-    batch = Repo.all(Batch.get_assoc_by_commit(commit))
-    case batch do
+    project_id
+    |> Batch.get_assoc_by_commit(commit)
+    |> Repo.all()
+    |> case do
       [batch] ->
-        ^project_id = batch.project_id
+        assert project_id == batch.project_id
         batch.id
         |> Status.get_for_batch(identifier)
         |> Repo.update_all([set: [state: state, url: url]])

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -136,7 +136,6 @@ defmodule BorsNG.Worker.Batcher do
     |> Repo.all()
     |> case do
       [batch] ->
-        assert project_id == batch.project_id
         batch.id
         |> Status.get_for_batch(identifier)
         |> Repo.update_all([set: [state: state, url: url]])


### PR DESCRIPTION
Fixes a crash experienced in production.