### PR TITLE
Avoid launching worker processes for dead projects

### DIFF
--- a/lib/database/project.ex
+++ b/lib/database/project.ex
@@ -40,6 +40,13 @@ defmodule BorsNG.Database.Project do
     timestamps()
   end
 
+  def active do
+    from p in Project,
+      join: b in Batch, on: p.id == b.project_id,
+      where: b.state == ^(:waiting)
+             or b.state == ^(:running)
+  end
+
   def installation_project_connection(project_id, repo) do
     {installation_xref, repo_xref} = from(p in Project,
       join: i in Installation, on: i.id == p.installation_id,

--- a/lib/worker/attemptor/registry.ex
+++ b/lib/worker/attemptor/registry.ex
@@ -32,7 +32,7 @@ defmodule BorsNG.Worker.Attemptor.Registry do
   # Server callbacks
 
   def init(:ok) do
-    names = Project
+    names = Project.active
     |> Repo.all()
     |> Enum.map(&{&1.id, do_start(&1.id)})
     |> Map.new()

--- a/lib/worker/batcher/registry.ex
+++ b/lib/worker/batcher/registry.ex
@@ -32,7 +32,7 @@ defmodule BorsNG.Worker.Batcher.Registry do
   # Server callbacks
 
   def init(:ok) do
-    names = Project
+    names = Project.active
     |> Repo.all()
     |> Enum.map(&{&1.id, do_start(&1.id)})
     |> Map.new()


### PR DESCRIPTION
Should reduce initial memory usage and crashes.