### PR TITLE
Fix "quoted keyword" style warnings on server startup

### DIFF
--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -115,7 +115,7 @@ defmodule BorsNG.GitHub.Server do
 
   def do_handle_call(:push, repo_conn, {sha, to}) do
     repo_conn
-    |> patch!("git/refs/heads/#{to}", Poison.encode!(%{"sha": sha}))
+    |> patch!("git/refs/heads/#{to}", Poison.encode!(%{sha: sha}))
     |> case do
       %{body: _, status_code: 200} ->
         {:ok, sha}
@@ -148,7 +148,7 @@ defmodule BorsNG.GitHub.Server do
     from: from,
     to: to,
     commit_message: commit_message}}) do
-    msg = %{"base": to, "head": from, "commit_message": commit_message}
+    msg = %{base: to, head: from, commit_message: commit_message}
     repo_conn
     |> post!("merges", Poison.encode!(msg))
     |> case do
@@ -174,12 +174,12 @@ defmodule BorsNG.GitHub.Server do
     parents: parents,
     commit_message: commit_message,
     committer: committer}}) do
-    msg = %{"parents": parents, "tree": tree, "message": commit_message}
+    msg = %{parents: parents, tree: tree, message: commit_message}
     msg = if is_nil committer do
       msg
     else
       Map.put(msg, "author", %{
-        "name": committer.name, "email": committer.email})
+        name: committer.name, email: committer.email})
     end
     repo_conn
     |> post!("git/commits", Poison.encode!(msg))
@@ -197,7 +197,7 @@ defmodule BorsNG.GitHub.Server do
     |> get!("branches/#{to}")
     |> case do
       %{status_code: 404} ->
-        msg = %{"ref": "refs/heads/#{to}", "sha": sha}
+        msg = %{ref: "refs/heads/#{to}", sha: sha}
         repo_conn
         |> post!("git/refs", Poison.encode!(msg))
         |> case do
@@ -208,7 +208,7 @@ defmodule BorsNG.GitHub.Server do
         end
       %{body: raw, status_code: 200} ->
         if sha != Poison.decode!(raw)["commit"]["sha"] do
-          msg = %{"force": true, "sha": sha}
+          msg = %{force: true, sha: sha}
           repo_conn
           |> patch!("git/refs/heads/#{to}", Poison.encode!(msg))
           |> case do

--- a/mix.exs
+++ b/mix.exs
@@ -37,7 +37,7 @@ defmodule BorsNg.Mixfile do
   # Run ecto setup before running tests.
   defp aliases do
     [
-      "test": ["ecto.create --quiet", "ecto.migrate", "test"]
+      test: ["ecto.create --quiet", "ecto.migrate", "test"]
     ]
   end
 


### PR DESCRIPTION
This is my first elixir PR, so I thought I'd make it something small.

Once I've found my way around the project, I might try to implement something to remember successful builds based on the tree-hash (as suggested here https://github.com/bors-ng/bors-ng/issues/185#issuecomment-360967484 ). Wish me luck.

The warnings look like this:
```
  warning: found quoted keyword "sha" but the quotes are not required.
  Note that keywords are always atoms, even when quoted, and quotes
  should only be used to introduce keywords with foreign characters
  in them
    lib/github/github/server.ex:200
```