### PR TITLE
Allow configuration of GitHub API timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,7 +23,9 @@ config :bors,
   api_github_root: {:system, :string, "GITHUB_URL_ROOT_API",
     "https://api.github.com"},
   html_github_root: {:system, :string, "GITHUB_URL_ROOT_HTML",
-    "https://github.com"}
+    "https://github.com"},
+  api_github_timeout: {:system, :integer, "GITHUB_API_TIMEOUT",
+    5000}
 
 # General application configuration
 config :bors, BorsNG,

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -35,7 +35,7 @@ defmodule BorsNG.GitHub do
   @spec get_pr(tconn, integer | bitstring) ::
     {:ok, BorsNG.GitHub.Pr.t} | {:error, term}
   def get_pr(repo_conn, pr_xref) do
-    GenServer.call(BorsNG.GitHub, {:get_pr, repo_conn, {pr_xref}})
+    GenServer.call(BorsNG.GitHub, {:get_pr, repo_conn, {pr_xref}}, Confex.fetch_env!(:bors, :api_github_timeout))
   end
 
   @spec get_pr_commits!(tconn, integer | bitstring) :: [BorsNG.GitHub.Commit.t]
@@ -47,7 +47,7 @@ defmodule BorsNG.GitHub do
   @spec get_pr_commits(tconn, integer | bitstring) ::
     {:ok, [BorsNG.GitHub.Commit.t]} | {:error, term}
   def get_pr_commits(repo_conn, pr_xref) do
-    GenServer.call(BorsNG.GitHub, {:get_pr_commits, repo_conn, {pr_xref}})
+    GenServer.call(BorsNG.GitHub, {:get_pr_commits, repo_conn, {pr_xref}}, Confex.fetch_env!(:bors, :api_github_timeout))
   end
 
   @spec get_open_prs!(tconn) :: [tpr]
@@ -61,20 +61,21 @@ defmodule BorsNG.GitHub do
 
   @spec push!(tconn, binary, binary) :: binary
   def push!(repo_conn, sha, to) do
-    {:ok, sha} = GenServer.call(BorsNG.GitHub, {:push, repo_conn, {sha, to}})
+    {:ok, sha} = GenServer.call(BorsNG.GitHub, {:push, repo_conn, {sha, to}}, Confex.fetch_env!(:bors, :api_github_timeout))
     sha
   end
 
   @spec push(tconn, binary, binary) :: {:ok, binary} | {:error, term, term}
   def push(repo_conn, sha, to) do
-    GenServer.call(BorsNG.GitHub, {:push, repo_conn, {sha, to}})
+    GenServer.call(BorsNG.GitHub, {:push, repo_conn, {sha, to}}, Confex.fetch_env!(:bors, :api_github_timeout))
   end
 
   @spec get_branch!(tconn, binary) :: %{commit: bitstring, tree: bitstring}
   def get_branch!(repo_conn, from) do
     {:ok, commit} = GenServer.call(
       BorsNG.GitHub,
-      {:get_branch, repo_conn, {from}})
+      {:get_branch, repo_conn, {from}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     commit
   end
 
@@ -82,7 +83,8 @@ defmodule BorsNG.GitHub do
   def delete_branch!(repo_conn, branch) do
     :ok = GenServer.call(
       BorsNG.GitHub,
-      {:delete_branch, repo_conn, {branch}})
+      {:delete_branch, repo_conn, {branch}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     :ok
   end
 
@@ -94,7 +96,8 @@ defmodule BorsNG.GitHub do
   def merge_branch!(repo_conn, info) do
     {:ok, commit} = GenServer.call(
       BorsNG.GitHub,
-      {:merge_branch, repo_conn, {info}})
+      {:merge_branch, repo_conn, {info}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     commit
   end
 
@@ -107,7 +110,8 @@ defmodule BorsNG.GitHub do
   def synthesize_commit!(repo_conn, info) do
     {:ok, sha} = GenServer.call(
       BorsNG.GitHub,
-      {:synthesize_commit, repo_conn, {info}})
+      {:synthesize_commit, repo_conn, {info}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     sha
   end
 
@@ -115,7 +119,8 @@ defmodule BorsNG.GitHub do
   def force_push!(repo_conn, sha, to) do
     {:ok, sha} = GenServer.call(
       BorsNG.GitHub,
-      {:force_push, repo_conn, {sha, to}})
+      {:force_push, repo_conn, {sha, to}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     sha
   end
 
@@ -124,7 +129,8 @@ defmodule BorsNG.GitHub do
   def get_commit_status!(repo_conn, sha) do
     {:ok, status} = GenServer.call(
       BorsNG.GitHub,
-      {:get_commit_status, repo_conn, {sha}})
+      {:get_commit_status, repo_conn, {sha}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     status
   end
 
@@ -132,7 +138,8 @@ defmodule BorsNG.GitHub do
   def get_labels!(repo_conn, issue_xref) do
     {:ok, labels} = GenServer.call(
       BorsNG.GitHub,
-      {:get_labels, repo_conn, {issue_xref}})
+      {:get_labels, repo_conn, {issue_xref}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     labels
   end
 
@@ -140,7 +147,8 @@ defmodule BorsNG.GitHub do
   def get_reviews!(repo_conn, issue_xref) do
     {:ok, labels} = GenServer.call(
       BorsNG.GitHub,
-      {:get_reviews, repo_conn, {issue_xref}})
+      {:get_reviews, repo_conn, {issue_xref}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     labels
   end
 
@@ -148,7 +156,8 @@ defmodule BorsNG.GitHub do
   def get_file!(repo_conn, branch, path) do
     {:ok, file} = GenServer.call(
       BorsNG.GitHub,
-      {:get_file, repo_conn, {branch, path}})
+      {:get_file, repo_conn, {branch, path}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     file
   end
 
@@ -156,7 +165,8 @@ defmodule BorsNG.GitHub do
   def post_comment!(repo_conn, number, body) do
     :ok = GenServer.call(
       BorsNG.GitHub,
-      {:post_comment, repo_conn, {number, body}})
+      {:post_comment, repo_conn, {number, body}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     :ok
   end
 
@@ -164,7 +174,8 @@ defmodule BorsNG.GitHub do
   def post_commit_status!(repo_conn, {sha, status, msg, url}) do
     :ok = GenServer.call(
       BorsNG.GitHub,
-      {:post_commit_status, repo_conn, {sha, status, msg, url}})
+      {:post_commit_status, repo_conn, {sha, status, msg, url}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     :ok
   end
 
@@ -172,7 +183,8 @@ defmodule BorsNG.GitHub do
   def get_user_by_login!(token, login) do
     {:ok, user} = GenServer.call(
       BorsNG.GitHub,
-      {:get_user_by_login, token, {login}})
+      {:get_user_by_login, token, {login}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
     user
   end
 
@@ -181,12 +193,13 @@ defmodule BorsNG.GitHub do
   def get_collaborators_by_repo(repo_conn) do
     GenServer.call(
       BorsNG.GitHub,
-      {:get_collaborators_by_repo, repo_conn, {}})
+      {:get_collaborators_by_repo, repo_conn, {}},
+      Confex.fetch_env!(:bors, :api_github_timeout))
   end
 
   @spec get_app!() :: String.t()
   def get_app! do
-    {:ok, app_link} = GenServer.call(BorsNG.GitHub, :get_app)
+    {:ok, app_link} = GenServer.call(BorsNG.GitHub, :get_app, Confex.fetch_env!(:bors, :api_github_timeout))
     app_link
   end
 


### PR DESCRIPTION
Fixes #579 

Added `GITHUB_API_TIMEOUT` envvar, defaulting to 5 seconds