### PR TITLE
When requesting the most recent command, exclude retry

### DIFF
--- a/lib/database/context/logging.ex
+++ b/lib/database/context/logging.ex
@@ -14,7 +14,7 @@ defmodule BorsNG.Database.Context.Logging do
   @spec most_recent_cmd(Patch.t) :: {User.t, BorsNG.Command.cmd} | nil
   def most_recent_cmd(%Patch{id: id}) do
     from(l in Log)
-    |> where([l], l.patch_id == ^id)
+    |> where([l], l.patch_id == ^id and l.cmd != ^:retry)
     |> order_by([l], [desc: l.updated_at, desc: l.id])
     |> preload([l], :user)
     |> limit(1)

--- a/test/context/logging_test.exs
+++ b/test/context/logging_test.exs
@@ -32,4 +32,12 @@ defmodule BorsNG.Database.Context.LoggingTest do
     user_id = user.id
     assert {%User{id: ^user_id}, :cmd2} = Logging.most_recent_cmd(patch)
   end
+
+  test "most recent command should exclude retry", params do
+    %{patch: patch, user: user} = params
+    Logging.log_cmd(patch, user, :cmd1)
+    Logging.log_cmd(patch, user, :retry)
+    user_id = user.id
+    assert {%User{id: ^user_id}, :cmd1} = Logging.most_recent_cmd(patch)
+  end
 end


### PR DESCRIPTION
Otherwise, retrying a retry will cause an infinite loop, either:

Resolves https://forum.bors.tech/t/bors-sometimes-doesnt-see-retry-messages-until-a-ping/278