### PR TITLE
Updating message when review is already running

### DIFF
--- a/lib/worker/attemptor.ex
+++ b/lib/worker/attemptor.ex
@@ -85,7 +85,7 @@ defmodule BorsNG.Worker.Attemptor do
         # There is already a running attempt
         project
         |> get_repo_conn()
-        |> send_message(patch, :not_awaiting_review)
+        |> send_message(patch, :already_running_review)
     end
   end
 
@@ -295,7 +295,7 @@ defmodule BorsNG.Worker.Attemptor do
   defp maybe_start_next_attempt(:running, _project) do
     :ok
   end
-  
+
   defp maybe_start_next_attempt(_state, project) do
     case Repo.one(Attempt.all_for_project(project.id, :waiting)) do
       nil -> :ok

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -107,7 +107,7 @@ defmodule BorsNG.Worker.Batcher do
         project = Repo.get!(Project, patch.project_id)
         project
         |> get_repo_conn()
-        |> send_message([patch], :not_awaiting_review)
+        |> send_message([patch], :already_running_review)
       patch ->
         # Patch exists and is awaiting review
         # This will cause the PR to start after the patch's scheduled delay

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -43,9 +43,6 @@ defmodule BorsNG.Worker.Batcher.Message do
   def generate_message({:preflight, :ci_skip}) do
     "Has [ci skip], bors build will time out"
   end
-  def generate_message(:not_awaiting_review) do
-    "Not awaiting review"
-  end
   def generate_message(:already_running_review) do
     "Already running a review"
   end

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -46,6 +46,9 @@ defmodule BorsNG.Worker.Batcher.Message do
   def generate_message(:not_awaiting_review) do
     "Not awaiting review"
   end
+  def generate_message(:already_running_review) do
+    "Already running a review"
+  end
   def generate_message({:config, message}) do
     "# Configuration problem\n#{message}"
   end

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -54,7 +54,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         branches: %{},
         commits: %{},
         comments: %{
-          1 => ["## try\n\nNot awaiting review"]
+          1 => ["## try\n\nAlready running a review"]
           },
         statuses: %{},
         files: %{}

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -242,7 +242,7 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{},
         commits: %{},
         comments: %{
-          1 => ["Not awaiting review"]
+          1 => ["Already running a review"]
           },
         statuses: %{},
         files: %{}


### PR DESCRIPTION
This PR replaces message `Not awaiting review` with `Already running a review` for Atemptor and Batcher messages when another review is in progress. It should resolve https://github.com/bors-ng/bors-ng/issues/568. Please let me know if there is anything else left to be changed. Also if suggested Batcher change is excess, I can remove it :) .  