### PR TITLE
Fix NPM license line

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "repository": {},
-  "license": "MIT",
+  "license": "APACHE-2.0",
   "scripts": {
     "deploy": "brunch build --production",
     "watch": "brunch watch --stdin"


### PR DESCRIPTION
Since the actual copyright notes within the repository all
say it's under the Apache license, and the two licenses
are compatible, it should be fine just changing it to match.