### PR TITLE
Infer the use of SemaphoreCI

### DIFF
--- a/lib/worker/batcher/get_bors_toml.ex
+++ b/lib/worker/batcher/get_bors_toml.ex
@@ -31,6 +31,7 @@ defmodule BorsNG.Worker.Batcher.GetBorsToml do
           {"jet-steps.json", "continuous-integration/codeship"},
           {"codeship-steps.yml", "continuous-integration/codeship"},
           {"codeship-steps.json", "continuous-integration/codeship"},
+          {".semaphore/semaphore.yml", "continuous-integration/semaphoreci"},
         ]
         |> Enum.filter(fn {file, _} ->
           not is_nil GitHub.get_file!(repo_conn, branch, file) end)

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -187,6 +187,21 @@ defmodule BorsNG.Worker.AttemptorTest do
     assert status.identifier == "continuous-integration/codeship"
   end
 
+  test "infer from .semaphore/semaphore.yml", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{"master" => "ini", "trying" => "", "trying.tmp" => ""},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"iniN" => []},
+        files: %{"trying.tmp" => %{".semaphore/semaphore.yml" => ""}}
+      }})
+    patch = new_patch(proj, 1, "N")
+    Attemptor.handle_cast({:tried, patch.id, "test"}, proj.id)
+    [status] = Repo.all(AttemptStatus)
+    assert status.identifier == "continuous-integration/semaphoreci"
+  end
+
   test "full runthrough (with polling fallback)", %{proj: proj} do
     # Attempts start running immediately
     GitHub.ServerMock.put_state(%{


### PR DESCRIPTION
Infer status configuration for SemaphoreCI based on the presence of the `.semaphore/semaphore.yml` config file.

Closes #591 