### PR TITLE
Correct phoenix task

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ You can then run it using `mix`:
 
     $ mix ecto.create
     $ mix ecto.migrate
-    $ mix phoenix.server
+    $ mix phx.server
 
 And it'll run with the GitHub API mocked-out.
 

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -10,7 +10,7 @@ defmodule BorsNG.GitHub.ServerMock do
   you can put and get its state,
   and other functions will mutate or read subsets of it.
 
-  For example, I can run `iex -S mix phoenix.server` and do this:
+  For example, I can run `iex -S mix phx.server` and do this:
 
       iex> # Push state to "GitHub"
       iex> alias BorsNG.GitHub

--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -3,7 +3,7 @@ defmodule BorsNG.WebhookController do
   The webhook controller responds to HTTP requests
   that are initiated from other services (currently, just GitHub).
 
-  For example, I can run `iex -S mix phoenix.server` and do this:
+  For example, I can run `iex -S mix phx.server` and do this:
 
       iex> # Push state to "GitHub"
       iex> alias BorsNG.GitHub

--- a/script/repl
+++ b/script/repl
@@ -6,4 +6,4 @@ done
 if [ -z $BORS_WITHIN_DOCKER ]; then
   exec docker exec -it borsng-dev "$0" "$@"
 fi
-iex -S mix phoenix.server
+iex -S mix phx.server

--- a/script/server
+++ b/script/server
@@ -7,4 +7,4 @@ if [ ! -f ../janitor.json ]; then
   docker start borsng-dev
   exec docker exec -it borsng-dev "$0" "$@"
 fi
-mix phoenix.server
+mix phx.server


### PR DESCRIPTION
The `mix.exs` of this project requires phoenix to be `"~> 1.4.3"`. Phoenix on v1.3.0 changed the task name from `phoenix.server` to `phx.server`; as such, files from the folder `/scripts/*` that refered to the former name do not work.

This pr simply replace the command `phoenix.server` to `phx.server` to make it work as expected