### PR TITLE
Make merge fail explicitly when an approved PR also has changes requested

### DIFF
--- a/lib/database/batch.ex
+++ b/lib/database/batch.ex
@@ -5,6 +5,8 @@ defmodule BorsNG.Database.Batch do
   A batch is a collection of patches that are running, or will run.
   """
 
+  @type t :: %__MODULE__{}
+
   use BorsNG.Database.Model
   alias BorsNG.Database.BatchState
 

--- a/lib/database/status.ex
+++ b/lib/database/status.ex
@@ -5,6 +5,7 @@ defmodule BorsNG.Database.Status do
   array of bors.toml.
   """
 
+  @type t :: %__MODULE__{}
   @type state_n :: 0 | 1 | 2 | 3
   @type state :: :waiting | :running | :ok | :error
 

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -383,6 +383,7 @@ defmodule BorsNG.Worker.Batcher do
     end
   end
 
+  @spec complete_batch(BorsNG.Database.Status.state, BorsNG.Database.Batch.t, term) :: term
   defp complete_batch(:ok, batch, statuses) do
     project = batch.project
     repo_conn = get_repo_conn(project)
@@ -558,7 +559,7 @@ defmodule BorsNG.Worker.Batcher do
     %{"CHANGES_REQUESTED" => failed, "APPROVED" => passed} = reviews
 
     case {failed, passed} do
-      {failed, 0} when failed > 0 -> :failed
+      {failed, _} when failed > 0 -> :failed
       {_, approved} when approved >= required -> :sufficient
       {0, _} -> :insufficient
     end

--- a/lib/worker/batcher/state.ex
+++ b/lib/worker/batcher/state.ex
@@ -5,23 +5,23 @@ defmodule BorsNG.Worker.Batcher.State do
   and emits a batch state.
   """
 
-  @typep n :: BorsNG.Database.Status.state_n
-  @typep t :: BorsNG.Database.Status.state
+  @typep status :: BorsNG.Database.Status.t
+  @typep state :: BorsNG.Database.Status.state
 
-  @spec summary_database_statuses([n]) :: t
+  @spec summary_database_statuses([status]) :: state
   def summary_database_statuses(statuses) do
     statuses
     |> Enum.map(&(&1.state))
     |> summary_states()
   end
 
-  @spec summary_states([t]) :: t
+  @spec summary_states([state]) :: state
   def summary_states(states) do
     states
     |> Enum.reduce(:ok, &summarize/2)
   end
 
-  @spec summarize(t, t) :: t
+  @spec summarize(state, state) :: state
   def summarize(self, rest) do
     case {self, rest} do
       {:error, _} -> :error

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -343,6 +343,38 @@ defmodule BorsNG.Worker.BatcherTest do
       }}
   end
 
+  test "rejects an patch with a request for changes even if it also has approvals", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"Z" => %{"cn" => :ok}},
+        reviews: %{1 => %{"APPROVED" => 2, "CHANGES_REQUESTED" => 1}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\nrequired_approvals = 1/}},
+      }})
+    patch = %Patch{
+      project_id: proj.id,
+      pr_xref: 1,
+      commit: "Z",
+      into_branch: "master"}
+    |> Repo.insert!()
+    Batcher.handle_cast({:reviewed, patch.id, "rvr"}, proj.id)
+    state = GitHub.ServerMock.get_state()
+    assert state == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{
+          1 => [":-1: Rejected by code reviews"]},
+        statuses: %{"Z" => %{"cn" => :ok}},
+        files: %{"Z" => %{"bors.toml" =>
+                           ~s/status = [ "ci" ]\nrequired_approvals = 1/}},
+        reviews: %{1 => %{"APPROVED" => 2, "CHANGES_REQUESTED" => 1}},
+      }}
+  end
+
   test "accepts a patch with a requested changes turned off", %{proj: proj} do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{


### PR DESCRIPTION
Currently here at Tink AB, frequently the following situation happens:

PR
- Person request changes
- New commit fix changes
- Gets approval and ask bors to merge
- Bors never says anything and nothing seems to happen
- Someone notices this and dismiss stale "changes requested"
- Ask for bors to merge and it works wonders

This is also correlated to #561 

This PR aims to solve this problem by getting bors to explicitly refuse (providing message) when a merge is requested but there are changes requested.

Some minor types were added (as I was using them to explore the code to find out where the problem was). They can be merged as I intend to provide more typespecs in following PRs

Edit:
Assertions to test:
- [x] has approvals, has disapprovals, should fail and return msg
- [ ] ~has approvals, has disapprovals, disapproval ignored in toml, should succeed~
- [ ] ~no approval, has disapprovals, disapproval ignored in toml, should succeed~

Edit2:
There's no semantics for "ignore disapprovals", the only configs seems to be either require approvals (at which time disapprovals are considered) or doesn't (where disapprovals are also ignored).

This semantics seems strange TBH. I'll keep them working but I believe that the possible branchs should be

- Required Approvals(int, 0 by default)
- Ignore disapprovals(bool, false by default)

So a 0 approval, 1 disapproval when approvals are not required does not seem to make sense in the usual case