### PR TITLE
Reorder presentation of batches

### DIFF
--- a/lib/database/batch.ex
+++ b/lib/database/batch.ex
@@ -50,16 +50,14 @@ defmodule BorsNG.Database.Batch do
 
   def all_for_project(project_id, :incomplete) do
     from b in all_for_project(project_id),
-      where: b.state == ^(:waiting) or b.state == ^(:running),
-      order_by: [desc: b.state]
+      where: b.state == ^(:waiting) or b.state == ^(:running)
   end
 
   def all_for_project(project_id, :complete) do
     from b in all_for_project(project_id),
       where: b.state == ^(:ok)
         or b.state == ^(:error)
-        or b.state == ^(:canceled),
-      order_by: [desc: b.state]
+        or b.state == ^(:canceled)
   end
 
   def all_for_project(project_id, state) do

--- a/lib/database/batch.ex
+++ b/lib/database/batch.ex
@@ -49,7 +49,8 @@ defmodule BorsNG.Database.Batch do
 
   def all_for_project(project_id, :incomplete) do
     from b in all_for_project(project_id),
-      where: b.state == ^(:waiting) or b.state == ^(:running)
+      where: b.state == ^(:waiting) or b.state == ^(:running),
+      order_by: b.state
   end
 
   def all_for_project(project_id, :complete) do

--- a/lib/database/batch.ex
+++ b/lib/database/batch.ex
@@ -42,7 +42,8 @@ defmodule BorsNG.Database.Batch do
 
   def all_for_project(project_id) do
     from b in Batch,
-      where: b.project_id == ^project_id
+      where: b.project_id == ^project_id,
+      order_by: [desc: b.state]
   end
 
   def all_for_project(project_id, nil), do: all_for_project(project_id)
@@ -50,14 +51,15 @@ defmodule BorsNG.Database.Batch do
   def all_for_project(project_id, :incomplete) do
     from b in all_for_project(project_id),
       where: b.state == ^(:waiting) or b.state == ^(:running),
-      order_by: b.state
+      order_by: [desc: b.state]
   end
 
   def all_for_project(project_id, :complete) do
     from b in all_for_project(project_id),
       where: b.state == ^(:ok)
         or b.state == ^(:error)
-        or b.state == ^(:canceled)
+        or b.state == ^(:canceled),
+      order_by: [desc: b.state]
   end
 
   def all_for_project(project_id, state) do

--- a/lib/web/templates/project/show.html.eex
+++ b/lib/web/templates/project/show.html.eex
@@ -21,18 +21,18 @@
   Nothing to see here
 <% else %>
 <table class="table">
-<%= if @unbatched_patches != [] do %>
+<%= for batch <- @batches do %>
   <thead>
     <tr role=heading><td aria-role=presentation colspan=4>
       <h2 class=header>
-        Awaiting review
-        <span class=header-count><%= Enum.count(@unbatched_patches) %></span>
+        <%= stringify_state batch.state %>
+        <span class=header-count><%= Enum.count(batch.patches) %></span>
       </h2>
     </td></tr>
     <tr role=row><th>#</th><th>Title</th><th>Priority</th><th>Commit</th></tr>
   </thead>
   <tbody>
-  <%= for patch <- @unbatched_patches do %>
+  <%= for patch <- batch.patches do %>
     <tr role="row">
       <td>
         <%= patch.pr_xref %>
@@ -52,18 +52,18 @@
   <% end %>
   </tbody>
 <% end %>
-<%= for batch <- @batches do %>
+<%= if @unbatched_patches != [] do %>
   <thead>
     <tr role=heading><td aria-role=presentation colspan=4>
       <h2 class=header>
-        <%= stringify_state batch.state %>
-        <span class=header-count><%= Enum.count(batch.patches) %></span>
+        Awaiting review
+        <span class=header-count><%= Enum.count(@unbatched_patches) %></span>
       </h2>
     </td></tr>
     <tr role=row><th>#</th><th>Title</th><th>Priority</th><th>Commit</th></tr>
   </thead>
   <tbody>
-  <%= for patch <- batch.patches do %>
+  <%= for patch <- @unbatched_patches do %>
     <tr role="row">
       <td>
         <%= patch.pr_xref %>


### PR DESCRIPTION
Based on #639 

Rationale: For someone administering a bors instance, usually it should be more important to see the build status instead of what still needs to be reviewed (as this would usually be done by checking the github notifications). And considering `:running | :waiting` is a short transitive state, the list of such batches is way shorter and will disappear quickly, so not affecting the use case of people that uses the web view to see what needs reviewing.

Note: also added an order to other queries on the batch model as to ensure consistency (ie: without an explicit ordering on postgres - and other dbs -, there's no order guarantee, so results are somewhat non-deterministic)