### PR TITLE
Sort repositories on Dashboard by name

### DIFF
--- a/lib/database/context/dashboard.ex
+++ b/lib/database/context/dashboard.ex
@@ -11,7 +11,7 @@ defmodule BorsNG.Database.Context.Dashboard do
     from(p in Project,
       join: l in LinkUserProject, on: p.id == l.project_id,
       where: l.user_id == ^user_id,
-      order_by: p.repo_xref)
+      order_by: [asc: p.name, asc: p.repo_xref])
     |> Repo.all()
   end
 
@@ -19,14 +19,18 @@ defmodule BorsNG.Database.Context.Dashboard do
     from(p in Project,
       join: l in LinkMemberProject, on: p.id == l.project_id,
       where: l.user_id == ^user_id,
-      order_by: p.repo_xref)
+      order_by: [asc: p.name, asc: p.repo_xref])
     |> Repo.all()
   end
 
   def my_projects(user_id, :all) do
-    my_projects(user_id, :reviewer)
-    |> Enum.concat(my_projects(user_id, :member))
-    |> Enum.uniq_by(&(&1.repo_xref))
+    from(p in Project,
+      left_join: lm in LinkMemberProject, on: p.id == lm.project_id,
+      left_join: lu in LinkUserProject, on: p.id == lu.project_id,
+      where: (lm.user_id == ^user_id or lu.user_id == ^user_id),
+      order_by: [asc: p.name, asc: p.repo_xref],
+      group_by: p.id)
+    |> Repo.all()
   end
 
   def my_patches(user_id, type \\ :all)

--- a/test/context/dashboard_test.exs
+++ b/test/context/dashboard_test.exs
@@ -90,7 +90,7 @@ defmodule BorsNG.Database.DashboardContextTest do
     projects = Dashboard.my_projects(user.id)
     assert Enum.count(projects) == 2
     ids = Enum.map(projects, &(&1.id))
-    assert [context.project.id, project2.id] == ids
+    assert [context.project.id, project2.id] == Enum.sort(ids)
   end
 
   test "grab patches that a particular user has", %{project: project} do


### PR DESCRIPTION
Closes #663

Decided to consolidate it using a `group_by`, this reduces the amount of data returned from DB, the amount of handshakes and the cost of enumerating it, while, in the meantime, the DB can optimize the resultset :>

Might add later some test to check this expectation (ie: add 3 projects, set as reviewer and member of them - in one of them, both - and check that the resultset is the expected)

Edit: Note that on #659 the `order_by: p.repo_xref` was added to ensure that the repo list is consistent (there is no implicit guarantee on ordering for RDBMS without an explicit ordering request). Since we need an order, as mentioned on #663, sorting alphabetically is what would be most helpful for our users as it's easier to find what you expect

Edit2: Thinking about this, it would also probably be a good addition to order the ProjectController.show/4 results. I think that ordering it by `patch.pr_xref DESC` would be the most useful ordering. What do you think ?