### PR TITLE
Add the "Bors enabled" badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 A merge bot for GitHub pull requests
 ====================================
 
-[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://bors.tech)
+[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://app.bors.tech/repositories/3)
 
 [Bors-NG] implements a continuous-testing workflow where the master branch never breaks.
 It integrates GitHub pull requests with a tool like [Travis CI] that runs your tests.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 A merge bot for GitHub pull requests
 ====================================
 
+[![Bors enabled](https://bors.tech/images/badge_small.svg)](https://bors.tech)
+
 [Bors-NG] implements a continuous-testing workflow where the master branch never breaks.
 It integrates GitHub pull requests with a tool like [Travis CI] that runs your tests.
 


### PR DESCRIPTION
We now have a "Bors enabled" badge that users of Bors can add to their repositories to show off that they use Bors. See [this forum thread](https://forum.bors.tech/t/add-a-bors-enabled-badge-for-marketing-advertising/334) for details.

This pull request adds the badge to the README of the Bors repository, because Bors itself uses Bors.

