### PR TITLE
Cut dependabot metadata off of commit messages

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,3 @@
 status = [ "continuous-integration/travis-ci/push", "Taskcluster (push)" ]
 block_labels = [ "S-do-not-merge-yet" ]
+cut_body_after = "<details>"


### PR DESCRIPTION
Fixes some problems with issues and stuff being mentioned when we merge them.