### PR TITLE
Include child team members in collaborators

### DIFF
--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -14,7 +14,7 @@ defmodule BorsNG.GitHub.Server do
   @installation_content_type "application/vnd.github.machine-man-preview+json"
   @check_content_type "application/vnd.github.antiope-preview+json"
   @content_type_raw "application/vnd.github.v3.raw"
-  @content_type "application/vnd.github.speedy-preview+json"
+  @content_type "application/vnd.github.v3+json"
 
   @type tconn :: GitHub.tconn
   @type ttoken :: GitHub.ttoken

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -13,6 +13,7 @@ defmodule BorsNG.GitHub.Server do
 
   @installation_content_type "application/vnd.github.machine-man-preview+json"
   @check_content_type "application/vnd.github.antiope-preview+json"
+  @team_content_type "application/vnd.github.hellcat-preview+json"
   @content_type_raw "application/vnd.github.v3.raw"
   @content_type "application/vnd.github.v3+json"
 
@@ -445,7 +446,7 @@ defmodule BorsNG.GitHub.Server do
   def get_collaborators_by_repo_(token, url, append) do
     params = get_url_params(url)
     "token #{token}"
-    |> tesla_client(@content_type)
+    |> tesla_client(@team_content_type)
     |> Tesla.get(url, query: params)
     |> case do
       {:ok, %{body: raw, status: 200, headers: headers}} ->


### PR DESCRIPTION
So I'm running into a problem where Bors sync isn't showing collaborators that I would be expecting it to show. The deciding factor _seems_ to be that this organization is very into nested teams, and anyone who is in the top-level team shows up, but anyone in a tested team does not show up. That plus GitHub's [Collaborator API docs][1] lead me to believe that Bors needs to use the `hellcat-preview` content type to get nested team members when syncing collaborators.

Anyone else run into this? Concerns, other thoughts?

[1]: https://developer.github.com/v3/repos/collaborators/