### PR TITLE
Add `merge` as an alias for `r+`

### DIFF
--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -134,6 +134,10 @@ defmodule BorsNG.Command do
   def parse_cmd("r+" <> _), do: [:activate]
   def parse_cmd("r-" <> _), do: [:deactivate]
   def parse_cmd("r=" <> arguments), do: parse_activation_args(arguments)
+  def parse_cmd("merge-" <> _), do: [:deactivate]
+  def parse_cmd("merge p=" <> rest), do: parse_priority(rest) ++ [:activate]
+  def parse_cmd("merge=" <> arguments), do: parse_activation_args(arguments)
+  def parse_cmd("merge" <> _), do: [:activate]
   def parse_cmd("delegate+" <> _), do: [:delegate]
   def parse_cmd("delegate=" <> arguments), do: parse_delegation_args(arguments)
   def parse_cmd("d+" <> _), do: [:delegate]

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -39,33 +39,46 @@ defmodule BorsNG.CommandTest do
   test "accept the bare command" do
     assert [{:try, ""}] == Command.parse("bors try")
     assert [:activate] == Command.parse("bors r+")
+    assert [:activate] == Command.parse("bors merge")
     assert [:deactivate] == Command.parse("bors r-")
+    assert [:deactivate] == Command.parse("bors merge-")
   end
 
   test "accept the case insensity bare command" do
     assert [{:try, ""}] == Command.parse("Bors try")
     assert [:activate] == Command.parse("Bors r+")
+    assert [:activate] == Command.parse("Bors merge")
     assert [:deactivate] == Command.parse("Bors r-")
+    assert [:deactivate] == Command.parse("Bors merge-")
   end
 
   test "accept priority" do
     assert [{:set_priority, 1}, :activate] == Command.parse("bors r+ p=1")
+    assert [{:set_priority, 1}, :activate] == Command.parse("bors merge p=1")
     assert [{:set_priority, 1}, {:activate_by, "me"}] ==
       Command.parse("bors r=me p=1")
+    assert [{:set_priority, 1}, {:activate_by, "me"}] ==
+      Command.parse("bors merge=me p=1")
     assert [{:set_priority, 1}] == Command.parse("bors p=1")
   end
 
   test "accept priority case insensity" do
     assert [{:set_priority, 1}, :activate] == Command.parse("Bors r+ p=1")
+    assert [{:set_priority, 1}, :activate] == Command.parse("Bors merge p=1")
     assert [{:set_priority, 1}, {:activate_by, "me"}] ==
       Command.parse("Bors r=me p=1")
+    assert [{:set_priority, 1}, {:activate_by, "me"}] ==
+      Command.parse("Bors merge=me p=1")
     assert [{:set_priority, 1}] == Command.parse("Bors p=1")
   end
 
   test "accept negative priority" do
     assert [{:set_priority, -1}, :activate] == Command.parse("bors r+ p=-1")
+    assert [{:set_priority, -1}, :activate] == Command.parse("bors merge p=-1")
     assert [{:set_priority, -1}, {:activate_by, "me"}] ==
       Command.parse("bors r=me p=-1")
+    assert [{:set_priority, -1}, {:activate_by, "me"}] ==
+      Command.parse("bors merge=me p=-1")
     assert [{:set_priority, -1}] == Command.parse("bors p=-1")
   end
 
@@ -76,6 +89,10 @@ defmodule BorsNG.CommandTest do
 
   test "accept command with colon after it" do
     assert [{:try, ""}] == Command.parse("bors: try")
+    assert [:activate] == Command.parse("bors: r+")
+    assert [:activate] == Command.parse("bors: merge")
+    assert [:deactivate] == Command.parse("bors: r-")
+    assert [:deactivate] == Command.parse("bors: merge-")
   end
 
   test "accept the try command with an argument" do
@@ -83,14 +100,22 @@ defmodule BorsNG.CommandTest do
   end
 
   test "accept more than one command in a single comment" do
-    expected = [
+    expected_1 = [
       {:try, ""},
       :deactivate]
-    command = """
+    command_1 = """
     bors try
     bors r-
     """
-    assert expected == Command.parse(command)
+    assert expected_1 == Command.parse(command_1)
+    expected_2 = [
+      {:try, ""},
+      :deactivate]
+    command_2 = """
+    bors try
+    bors merge-
+    """
+    assert expected_2 == Command.parse(command_2)
   end
 
   test "accept the try command with more argumentation" do
@@ -424,11 +449,15 @@ defmodule BorsNG.CommandTest do
 
     assert [] == Command.parse("bors try")
     assert [] == Command.parse("bors r+")
+    assert [] == Command.parse("bors merge")
     assert [] == Command.parse("bors r-")
+    assert [] == Command.parse("bors merge-")
 
     assert [{:try, ""}] == Command.parse("popo try")
     assert [:activate] == Command.parse("popo r+")
+    assert [:activate] == Command.parse("popo merge")
     assert [:deactivate] == Command.parse("popo r-")
+    assert [:deactivate] == Command.parse("popo merge-")
     
     if old_env do
       System.put_env("COMMAND_TRIGGER", old_env)


### PR DESCRIPTION
This pull request implements the following RFC: [Allow `merge` as an alias for `r+`](https://forum.bors.tech/t/allow-merge-as-an-alias-for-r/376)

Specifically, this pull request adds the following aliases:

| Alias added in this PR | Existing command |
| ---------------------- | ------------------ |
| `bors merge` | `bors r+` |
| `bors merge=FOO` | `bors r=FOO` |
| `bors merge p=123` | `bors r+ p=123` |
| `bors merge=FOO p=123` | `bors r=FOO p=123` |
| `bors merge-` | `bors r-` |