### PR TITLE
Adding support for asterisk on CodeOwners

### DIFF
--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -44,7 +44,7 @@ defmodule BorsNG.CodeOwnerParser do
               owner.approvers
              String.starts_with?(x.filename, owner.file_pattern) ->
               owner.approvers
-            true ->
+             true ->
               nil # if unknown fall through
             end
           end)
@@ -60,7 +60,7 @@ defmodule BorsNG.CodeOwnerParser do
             end
           end)
       end)
-        
+ 
     required_reviewers = Enum.filter(required_reviewers, fn x -> x != nil end)
 
     Logger.debug("Required reviewers: #{inspect(required_reviewers)}")

--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -75,7 +75,7 @@ defmodule BorsNG.CodeOwnerParser do
       String.starts_with?(file_pattern, double_asterisk) ->
         pattern = String.trim_leading(file_pattern, double_asterisk)
         String.contains?(file_name, pattern)
-      String.ends_with?(file_name, double_asterisk) ->
+      String.ends_with?(file_pattern, double_asterisk) ->
         pattern = String.trim_trailing(file_pattern, double_asterisk)
         String.starts_with?(file_name, pattern)
       String.contains?(file_pattern, double_asterisk) ->

--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -76,7 +76,7 @@ defmodule BorsNG.CodeOwnerParser do
         pattern = String.trim_leading(file_pattern, double_asterisk)
         String.contains?(file_name, pattern)
       String.ends_with?(file_name, double_asterisk) ->
-        pattern = String.trim_leading(file_pattern, double_asterisk)
+        pattern = String.trim_trailing(file_pattern, double_asterisk)
         String.starts_with?(file_name, pattern)
       String.contains?(file_pattern, double_asterisk) ->
         patterns = String.split(file_pattern, double_asterisk, parts: 2)

--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -35,12 +35,16 @@ defmodule BorsNG.CodeOwnerParser do
          # Convert each file to an array of matching owners
          pats = Enum.map(code_owners.patterns, fn owner ->
             cond do
-              # glob matches has an extra '/' in it, don't match on it
+             String.equivalent?("*", owner.file_pattern) ->
+              owner.approvers
+             String.contains?(owner.file_pattern, "**") && process_double_asterisk(x.filename, owner.file_pattern) ->
+              owner.approvers
+             # glob matches has an extra '/' in it, don't match on it
              :glob.matches(x.filename, owner.file_pattern) && !:glob.matches(x.filename, owner.file_pattern <> "/*")  ->
-                owner.approvers
+              owner.approvers
              String.starts_with?(x.filename, owner.file_pattern) ->
               owner.approvers
-             true ->
+            true ->
               nil # if unknown fall through
             end
           end)
@@ -56,12 +60,28 @@ defmodule BorsNG.CodeOwnerParser do
             end
           end)
       end)
-
+        
     required_reviewers = Enum.filter(required_reviewers, fn x -> x != nil end)
 
     Logger.debug("Required reviewers: #{inspect(required_reviewers)}")
 
     required_reviewers
+  end
+
+  @spec process_double_asterisk(String.t, String.t) :: boolean
+  def process_double_asterisk(file_name, file_pattern) do
+    double_asterisk = "**"
+    cond do
+      String.starts_with?(file_pattern, double_asterisk) ->
+        pattern = String.trim_leading(file_pattern, double_asterisk)
+        String.contains?(file_name, pattern)
+      String.ends_with?(file_name, double_asterisk) ->
+        pattern = String.trim_leading(file_pattern, double_asterisk)
+        String.starts_with?(file_name, pattern)
+      String.contains?(file_pattern, double_asterisk) ->
+        patterns = String.split(file_pattern, double_asterisk, parts: 2)
+        String.starts_with?(file_name, List.first(patterns)) && String.contains?(file_name, List.last(patterns))
+    end
   end
 
   @spec parse_file(String.t) :: {:ok, %BorsNG.CodeOwners{}}

--- a/test/parse_owners_test.exs
+++ b/test/parse_owners_test.exs
@@ -131,4 +131,77 @@ defmodule BorsNG.ParseTest do
     assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/my_other_team"
   end
 
+  test "Test Asterisk" do
+
+    IO.inspect(File.cwd())
+    {:ok, codeowner} = File.read("test/testdata/code_owners_6")
+
+    {:ok, owner_file} = BorsNG.CodeOwnerParser.parse_file(codeowner)
+
+    files = [%BorsNG.GitHub.File{
+      filename: "some_folder/some_file"
+    }]
+
+    reviewers = BorsNG.CodeOwnerParser.list_required_reviews(owner_file, files)
+
+    assert Enum.count(reviewers) == 1
+    assert Enum.count(Enum.at(reviewers, 0)) == 2
+    assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/my_team"
+    assert Enum.at(Enum.at(reviewers, 0), 1) == "@my_org/my_other_team"
+  end
+
+  test "Test Double Asterisk in the middle" do
+
+    IO.inspect(File.cwd())
+    {:ok, codeowner} = File.read("test/testdata/code_owners_7")
+
+    {:ok, owner_file} = BorsNG.CodeOwnerParser.parse_file(codeowner)
+
+    files = [%BorsNG.GitHub.File{
+      filename: "src/file1/test"
+    }]
+
+    reviewers = BorsNG.CodeOwnerParser.list_required_reviews(owner_file, files)
+
+    assert Enum.count(reviewers) == 1
+    assert Enum.count(Enum.at(reviewers, 0)) == 1
+    assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/test_team_2"
+  end
+
+  test "Test Double Asterisk in the beggining" do
+
+    IO.inspect(File.cwd())
+    {:ok, codeowner} = File.read("test/testdata/code_owners_7")
+
+    {:ok, owner_file} = BorsNG.CodeOwnerParser.parse_file(codeowner)
+
+    files = [%BorsNG.GitHub.File{
+      filename: "file0/file1/test"
+    }]
+
+    reviewers = BorsNG.CodeOwnerParser.list_required_reviews(owner_file, files)
+
+    assert Enum.count(reviewers) == 1
+    assert Enum.count(Enum.at(reviewers, 0)) == 1
+    assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/test_team"
+  end
+
+  test "Test Double Asterisk in the end" do
+
+    IO.inspect(File.cwd())
+    {:ok, codeowner} = File.read("test/testdata/code_owners_7")
+
+    {:ok, owner_file} = BorsNG.CodeOwnerParser.parse_file(codeowner)
+
+    files = [%BorsNG.GitHub.File{
+      filename: "other/file1/file2"
+    }]
+
+    reviewers = BorsNG.CodeOwnerParser.list_required_reviews(owner_file, files)
+
+    assert Enum.count(reviewers) == 1
+    assert Enum.count(Enum.at(reviewers, 0)) == 1
+    assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/other_team"
+  end
+
 end

--- a/test/testdata/code_owners_6
+++ b/test/testdata/code_owners_6
@@ -1,0 +1,6 @@
+* @my_org/my_team  @my_org/my_other_team
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+docs/*  @my_org/another_team

--- a/test/testdata/code_owners_6
+++ b/test/testdata/code_owners_6
@@ -1,3 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
 * @my_org/my_team  @my_org/my_other_team
 
 # The `docs/*` pattern will match files like

--- a/test/testdata/code_owners_7
+++ b/test/testdata/code_owners_7
@@ -3,7 +3,19 @@
 # `docs/build-app/troubleshooting.md`.
 src/  @my_org/another_team
 
+# A leading "**" followed by a slash means match in all directories. 
+# For example, "**/foo" matches file or directory "foo" anywhere, 
+# the same as pattern "foo". "**/foo/bar" matches file or directory "bar" 
+# anywhere that is directly under directory "foo".
 **/test @my_org/test_team
-src/**/core @my_org/core_team
+
+# A trailing "/**" matches everything inside. For example, "abc/**" 
+# matches all files inside directory "abc", relative to the location of 
+# the .gitignore file, with infinite depth.
 other/** @my_org/other_team
+
+# A slash followed by two consecutive asterisks then a slash matches 
+# zero or more directories. For example, "a/**/b" matches "a/b", "a/x/b", 
+# "a/x/y/b" and so on.
+src/**/core @my_org/core_team
 src/**/test @my_org/test_team_2

--- a/test/testdata/code_owners_7
+++ b/test/testdata/code_owners_7
@@ -1,0 +1,9 @@
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+src/  @my_org/another_team
+
+**/test @my_org/test_team
+src/**/core @my_org/core_team
+other/** @my_org/other_team
+src/**/test @my_org/test_team_2


### PR DESCRIPTION
Follow up from https://github.com/bors-ng/bors-ng/pull/725

There were some logic missing for CodeOwners check, namely:
- Global fallback with `*`
- Two consecutive asterisks `**` in patterns matched against full pathname

I did a super simple approach, not sure if it's the best one. Feedbacks appreciated.