### PR TITLE
Format generated commit message

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -357,7 +357,7 @@ defmodule BorsNG.Worker.Batcher do
               %{
                 tree: merge_commit.tree,
                 parents: [prev_head],
-                commit_message: "#{pr.title} (##{pr.number})\n#{pr.body}",
+                commit_message: "#{pr.title} (##{pr.number})\n\n#{pr.body}",
                 committer: %{name: user.login, email: user_email}})
 
             Logger.info("Commit Sha #{inspect(cpt)}")


### PR DESCRIPTION
Subject and body in commit message should be separated with a blank line.

For example, if the title is:

```
Title
```

and the body is

```
Paragraph 1 

Paragraph 2
```

Then the generated commit message should be:

```
Title

Paragraph 1 

Paragraph 2
```

not:

```
Title
Paragraph 1 

Paragraph 2
```