### PR TITLE
Handle CODEOWNERS with a double asterix and a leading slash

### DIFF
--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -110,7 +110,7 @@ defmodule BorsNG.CodeOwnerParser do
           approvers = Enum.slice(segments, 1, Enum.count(segments) - 1)
 
           %BorsNG.FilePattern{
-            file_pattern: Enum.at(segments, 0),
+            file_pattern: String.trim_leading(Enum.at(segments, 0), "/"),
             approvers: approvers
           }
         end)

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -518,7 +518,7 @@ defmodule BorsNG.Worker.BatcherTest do
           pr_status = [ "cn" ]
           use_codeowners = true
           """,
-          "/lib/go-mercury/init.go" =>
+          "lib/go-mercury/init.go" =>
           ~s"""
                       func init() {}
             """},
@@ -568,7 +568,7 @@ defmodule BorsNG.Worker.BatcherTest do
                  pr_status = [ "cn" ]
                  use_codeowners = true
                  """,
-                 "/lib/go-mercury/init.go" =>
+                 "lib/go-mercury/init.go" =>
                    ~s"""
                              func init() {}
                    """},

--- a/test/testdata/code_owners_8
+++ b/test/testdata/code_owners_8
@@ -1,0 +1,6 @@
+* @my_org/catch-all
+
+/foo/**/*.yaml @my_org/team-b @my_org/team-c
+bar/**/*.css @my_org/team-d @my_org/team-e
+
+/docs/ @my_org/team-f


### PR DESCRIPTION
This fixes #804

There seems to be a few testcases that incorrectly sets a leading slash when matching filepaths, but as far as I can see, no leading slash is set in production environments.