### PR TITLE
Use destination branch name in squash+merge comment

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -529,7 +529,7 @@ defmodule BorsNG.Worker.Batcher do
         pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
         pr = %BorsNG.GitHub.Pr{pr | state: :closed, title: "[Merged by Bors] - #{pr.title}"}
         pr = GitHub.update_pr!(repo_conn, pr)
-        GitHub.post_comment!(repo_conn, patch.pr_xref, "# Pull request successfully merged into master.")
+        send_message(repo_conn, [patch], {:merged, :squashed, "master"})
       end)
     end
 

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -529,7 +529,7 @@ defmodule BorsNG.Worker.Batcher do
         pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
         pr = %BorsNG.GitHub.Pr{pr | state: :closed, title: "[Merged by Bors] - #{pr.title}"}
         pr = GitHub.update_pr!(repo_conn, pr)
-        send_message(repo_conn, [patch], {:merged, :squashed, "master"})
+        send_message(repo_conn, [patch], {:merged, :squashed, batch.into_branch})
       end)
     end
 

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -89,6 +89,9 @@ defmodule BorsNG.Worker.Batcher.Message do
     end
     Enum.reduce(statuses, "# #{msg}", &gen_status_link/2)
   end
+  def generate_message({:merged, :squashed, target_branch}) do
+    "# Pull request successfully merged into #{target_branch}."
+  end
   defp gen_status_link(status, acc) do
     status_link = case status.url do
       nil -> status.identifier

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -49,6 +49,12 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     assert expected_message == actual_message
   end
 
+  test "generate merged into master message" do
+    expected_message = "# Pull request successfully merged into master."
+    actual_message = Message.generate_message({:merged, :squashed, "master"})
+    assert expected_message == actual_message
+  end
+
   test "generate commit message" do
     expected_message = """
     Merge #1 #2


### PR DESCRIPTION
This change updates batcher to comment with the name of the branch the merge was performed in, rather than hard-coding `# Pull request successfully merged into master.`.

refactor: produce squash merge message in message.ex
feat: comment correct branch name in squash merge