### PR TITLE
Rename PR after sending all the comments

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -524,16 +524,17 @@ defmodule BorsNG.Worker.Batcher do
     |> Patch.all_for_batch()
     |> Repo.all()
 
+    send_message(repo_conn, patches, {:succeeded, statuses})
+
     if toml.use_squash_merge do
       Enum.each(patches, fn patch ->
+        GitHub.post_comment!(repo_conn, patch.pr_xref, "# Pull request successfully merged into master.")
         pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
         pr = %BorsNG.GitHub.Pr{pr | state: :closed, title: "[Merged by Bors] - #{pr.title}"}
         pr = GitHub.update_pr!(repo_conn, pr)
         send_message(repo_conn, [patch], {:merged, :squashed, batch.into_branch})
       end)
     end
-
-    send_message(repo_conn, patches, {:succeeded, statuses})
   end
 
   defp complete_batch(:error, batch, statuses) do
@@ -886,7 +887,7 @@ defmodule BorsNG.Worker.Batcher do
     |> where([s], s.batch_id in ^ids)
     |> Repo.delete_all()
 
-    
+
     Enum.each(batches, &send_status(repo_conn, &1, :delayed))
     Batch
     |> where([b], b.id in ^ids)

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -528,11 +528,10 @@ defmodule BorsNG.Worker.Batcher do
 
     if toml.use_squash_merge do
       Enum.each(patches, fn patch ->
-        GitHub.post_comment!(repo_conn, patch.pr_xref, "# Pull request successfully merged into master.")
+        send_message(repo_conn, [patch], {:merged, :squashed, batch.into_branch})
         pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
         pr = %BorsNG.GitHub.Pr{pr | state: :closed, title: "[Merged by Bors] - #{pr.title}"}
         pr = GitHub.update_pr!(repo_conn, pr)
-        send_message(repo_conn, [patch], {:merged, :squashed, batch.into_branch})
       end)
     end
   end


### PR DESCRIPTION
Context: 
Changing the PR title then adding comments to the PR would trigger email clients like Gmail to think it is a different thread in email notifications.