### PR TITLE
Add Batch details page that links from Repository history tab

### DIFF
--- a/lib/web/controllers/batch_controller.ex
+++ b/lib/web/controllers/batch_controller.ex
@@ -8,6 +8,7 @@ defmodule BorsNG.BatchController do
   use BorsNG.Web, :controller
 
   alias BorsNG.Database.Batch
+  alias BorsNG.Database.Context.Permission
   alias BorsNG.Database.Repo
   alias BorsNG.Database.Patch
   alias BorsNG.Database.Project
@@ -16,6 +17,24 @@ defmodule BorsNG.BatchController do
   def show(conn, %{"id" => id}) do
     batch = Repo.get(Batch, id)
     project = Repo.get(Project, batch.project_id)
+
+    allow_private_repos = Confex.fetch_env!(:bors, BorsNG)[:allow_private_repos]
+    admin? = conn.assigns.user.is_admin
+    mode = conn.assigns.user
+    |> Permission.get_permission(project)
+    |> case do
+      _ when admin? -> :rw
+      :reviewer -> :rw
+      :member -> :ro
+      _ when not allow_private_repos -> :ro
+      _ -> raise BorsNG.PermissionDeniedError
+    end
+
+    case mode do
+      :ro -> raise BorsNG.PermissionDeniedError
+      _ ->
+    end
+
     patches = Repo.all(Patch.all_for_batch(batch.id))
     statuses = Repo.all(Status.all_for_batch(batch.id))
     render conn, "show.html", batch: batch, patches: patches, project: project, statuses: statuses

--- a/lib/web/controllers/batch_controller.ex
+++ b/lib/web/controllers/batch_controller.ex
@@ -1,0 +1,23 @@
+defmodule BorsNG.BatchController do
+  @moduledoc """
+  The controller for the batches
+
+  This will either show a batch detail page
+  """
+
+  use BorsNG.Web, :controller
+
+  alias BorsNG.Database.Batch
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.Patch
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.Status
+
+  def show(conn, %{"id" => id}) do
+    batch = Repo.get(Batch, id)
+    project = Repo.get(Project, batch.project_id)
+    patches = Repo.all(Patch.all_for_batch(batch.id))
+    statuses = Repo.all(Status.all_for_batch(batch.id))
+    render conn, "show.html", batch: batch, patches: patches, project: project, statuses: statuses
+  end
+end

--- a/lib/web/router.ex
+++ b/lib/web/router.ex
@@ -45,6 +45,14 @@ defmodule BorsNG.Router do
     get "/", PageController, :index
   end
 
+  scope "/batches", BorsNG do
+    pipe_through :browser_page
+    pipe_through :browser_session
+    pipe_through :browser_login
+
+    get "/:id", BatchController, :show
+  end
+
   scope "/repositories", BorsNG do
     pipe_through :browser_page
     pipe_through :browser_session

--- a/lib/web/templates/batch/show.html.eex
+++ b/lib/web/templates/batch/show.html.eex
@@ -1,39 +1,29 @@
 <main role=main><div class=wrapper>
 
-<h2 class=header>Batch details</h2>
+<h2 class=header>Batch Details</h2>
 
-<table id="batch-details-table" class="table">
-  <tbody>
-    <%= if @batch do %>
-      <tr>
-        <td>State</td>
-        <td><%= @batch.state %></td>
-      </tr>
-      <tr>
-        <td>Priority</td>
-        <td><%= @batch.priority %></td>
-      </tr>
-
-      <tr>
-        <td>Pull requests</td>
-        <td>
-          <%= for patch <- @patches do %>
-            <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
-          <% end %>
-        </td>
-      </tr>
-      <tr>
-        <td>Statuses</td>
-        <td>
-          <%= for status <- @statuses do %>
-            <a href="<%= status.url %>"><%= status.identifier %></a>
-          <% end %>
-        </td>
-      </tr>
-  <% else %>
-    There is no such batch
+<%= if @batch do %>
+<p>Priority: <%= @batch.priority %></p>
+<p>State: <%= stringify_state(@batch.state) %></p>
+<p>
+  Status:
+  <%= for status <- @statuses do %>
+    <%= if status.url do %>
+    <a href="<%= status.url %>"><%= status.identifier %></a>
+    <% else %>
+    <span><%= status.identifier %></span>
+    <% end %>
   <% end %>
-  </tbody>
-</table>
+</p>
+<p>
+  Pull Requests:
+  <%= for patch <- @patches do %>
+  <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
+  <% end %>
+</p>
+
+<% else %>
+There is no such batch
+<% end %>
 
 </div></main>

--- a/lib/web/templates/batch/show.html.eex
+++ b/lib/web/templates/batch/show.html.eex
@@ -9,9 +9,9 @@
   Status:
   <%= for status <- @statuses do %>
     <%= if status.url do %>
-    <a href="<%= status.url %>"><%= status.identifier %></a>
+    <a href="<%= status.url %>"><%= status.identifier %> (<%= stringify_state(status.state) %>)</a>
     <% else %>
-    <span><%= status.identifier %></span>
+    <span><%= status.identifier %> (<%= stringify_state(status.state) %>)</span>
     <% end %>
   <% end %>
 </p>

--- a/lib/web/templates/batch/show.html.eex
+++ b/lib/web/templates/batch/show.html.eex
@@ -1,0 +1,39 @@
+<main role=main><div class=wrapper>
+
+<h2 class=header>Batch details</h2>
+
+<table id="batch-details-table" class="table">
+  <tbody>
+    <%= if @batch do %>
+      <tr>
+        <td>State</td>
+        <td><%= @batch.state %></td>
+      </tr>
+      <tr>
+        <td>Priority</td>
+        <td><%= @batch.priority %></td>
+      </tr>
+
+      <tr>
+        <td>Pull requests</td>
+        <td>
+          <%= for patch <- @patches do %>
+            <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
+          <% end %>
+        </td>
+      </tr>
+      <tr>
+        <td>Statuses</td>
+        <td>
+          <%= for status <- @statuses do %>
+            <a href="<%= status.url %>"><%= status.identifier %></a>
+          <% end %>
+        </td>
+      </tr>
+  <% else %>
+    There is no such batch
+  <% end %>
+  </tbody>
+</table>
+
+</div></main>

--- a/lib/web/templates/project/log_page.html.eex
+++ b/lib/web/templates/project/log_page.html.eex
@@ -3,7 +3,6 @@
   <% %BorsNG.Database.Crash{id: id, component: component, crash: crash, updated_at: updated_at} -> %>
     <tr role=row id="crash-<%= id %>" data-id="<%= id %>" data-datetime="<%= updated_at %>">
       <td><%= htmlify_naive_datetime(updated_at) %></td>
-      <td></td>
       <td>Crash</td>
       <td><%= component %></td>
       <td><pre><code><%= crash %></code></pre></td>
@@ -11,8 +10,7 @@
   <% %BorsNG.Database.Batch{id: id, state: state, patches: patches, updated_at: updated_at} -> %>
     <tr role=row id="batch-<%= id %>" data-id="<%= id %>" data-datetime="<%= updated_at %>">
       <td><%= htmlify_naive_datetime(updated_at) %></td>
-      <td><a href="/batches/<%= id %>"><%= id %></a></td>
-      <td>Batch</td>
+      <td><a href="/batches/<%= id %>">Batch <%= id %></a></td>
       <td><%= stringify_state(state) %></td>
       <td>
       <%= for patch <- patches do %>

--- a/lib/web/templates/project/log_page.html.eex
+++ b/lib/web/templates/project/log_page.html.eex
@@ -3,6 +3,7 @@
   <% %BorsNG.Database.Crash{id: id, component: component, crash: crash, updated_at: updated_at} -> %>
     <tr role=row id="crash-<%= id %>" data-id="<%= id %>" data-datetime="<%= updated_at %>">
       <td><%= htmlify_naive_datetime(updated_at) %></td>
+      <td></td>
       <td>Crash</td>
       <td><%= component %></td>
       <td><pre><code><%= crash %></code></pre></td>
@@ -10,6 +11,7 @@
   <% %BorsNG.Database.Batch{id: id, state: state, patches: patches, updated_at: updated_at} -> %>
     <tr role=row id="batch-<%= id %>" data-id="<%= id %>" data-datetime="<%= updated_at %>">
       <td><%= htmlify_naive_datetime(updated_at) %></td>
+      <td><a href="/batches/<%= id %>"><%= id %></a></td>
       <td>Batch</td>
       <td><%= stringify_state(state) %></td>
       <td>

--- a/lib/web/views/batch_view.ex
+++ b/lib/web/views/batch_view.ex
@@ -4,4 +4,15 @@ defmodule BorsNG.BatchView do
   """
 
   use BorsNG.Web, :view
+
+  def stringify_state(state) do
+    case state do
+      :waiting  -> "Waiting to run"
+      :running  -> "Running"
+      :ok       -> "Succeeded"
+      :error    -> "Failed"
+      :canceled -> "Canceled"
+      _         -> "Invalid"
+    end
+  end
 end

--- a/lib/web/views/batch_view.ex
+++ b/lib/web/views/batch_view.ex
@@ -1,0 +1,7 @@
+defmodule BorsNG.BatchView do
+  @moduledoc """
+  Batch details page
+  """
+
+  use BorsNG.Web, :view
+end

--- a/test/controllers/batch_controller_test.exs
+++ b/test/controllers/batch_controller_test.exs
@@ -1,0 +1,80 @@
+defmodule BorsNG.BatchControllerTest do
+  use BorsNG.ConnCase
+
+  alias BorsNG.Database.Batch
+  alias BorsNG.Database.Installation
+  alias BorsNG.Database.LinkPatchBatch
+  alias BorsNG.Database.Patch
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.Status
+  alias BorsNG.Database.User
+
+  setup do
+    installation = Repo.insert!(%Installation{
+      installation_xref: 31,
+      })
+    project = Repo.insert!(%Project{
+      installation_id: installation.id,
+      repo_xref: 13,
+      name: "example/project",
+      })
+    user = Repo.insert!(%User{
+      user_xref: 23,
+      login: "ghost",
+      })
+    patch = Repo.insert!(%Patch{
+      project_id: project.id,
+      pr_xref: 43
+    })
+    batch = Repo.insert!(%Batch{
+      project_id: project.id,
+      priority: 33
+    })
+    {:ok, installation: installation, project: project, user: user, batch: batch, patch: patch}
+  end
+
+  test "need to log in to see this", %{conn: conn, batch: batch} do
+    conn = get conn, "/batches/#{batch.id}"
+    assert html_response(conn, 302) =~ "auth"
+  end
+
+  def login(conn) do
+    conn = get conn, auth_path(conn, :index, "github")
+    assert html_response(conn, 302) =~ "MOCK_GITHUB_AUTHORIZE_URL"
+    conn = get conn, auth_path(
+      conn,
+      :callback,
+      "github",
+      %{"code" => "MOCK_GITHUB_AUTHORIZE_CODE"})
+    html_response(conn, 302)
+    conn
+  end
+
+  test "shows the batch details", %{conn: conn, patch: patch, batch: batch} do
+    Repo.insert!(%LinkPatchBatch{
+      patch_id: patch.id,
+      batch_id: batch.id,
+    })
+    Repo.insert!(%Status{
+      batch_id: batch.id,
+      identifier: "some-identifier"
+    })
+    Repo.insert!(%Status{
+      batch_id: batch.id,
+      identifier: "with-url-identifier",
+      url: "http://example.com"
+    })
+
+    conn = login conn
+    conn = get conn, "/batches/#{batch.id}"
+
+    assert html_response(conn, 200) =~ "Batch Details"
+    assert html_response(conn, 200) =~ "Priority: 33"
+    assert html_response(conn, 200) =~ "State: Invalid"
+    assert html_response(conn, 200) =~ "#43"
+    assert html_response(conn, 200) =~ "<span>some-identifier</span>"
+    assert html_response(conn, 200) =~ ~S(<a href="http://example.com">with-url-identifier</a>)
+  end
+
+end

--- a/test/controllers/batch_controller_test.exs
+++ b/test/controllers/batch_controller_test.exs
@@ -39,12 +39,14 @@ defmodule BorsNG.BatchControllerTest do
     })
     Repo.insert!(%Status{
       batch_id: batch.id,
-      identifier: "some-identifier"
+      identifier: "some-identifier",
+      state: :running
     })
     Repo.insert!(%Status{
       batch_id: batch.id,
       identifier: "with-url-identifier",
-      url: "http://example.com"
+      url: "http://example.com",
+      state: :waiting
     })
     {:ok, installation: installation, project: project, user: user, batch: batch, user: user}
   end
@@ -87,8 +89,8 @@ defmodule BorsNG.BatchControllerTest do
     assert html_response(conn, 200) =~ "Priority: 33"
     assert html_response(conn, 200) =~ "State: Invalid"
     assert html_response(conn, 200) =~ "#43"
-    assert html_response(conn, 200) =~ "<span>some-identifier</span>"
-    assert html_response(conn, 200) =~ ~S(<a href="http://example.com">with-url-identifier</a>)
+    assert html_response(conn, 200) =~ "<span>some-identifier (Running)</span>"
+    assert html_response(conn, 200) =~ ~s(<a href="http://example.com">with-url-identifier (Waiting to run\)</a>)
   end
 
   test "hides batch details from a member", %{conn: conn, batch: batch, user: user, project: project} do


### PR DESCRIPTION
Hey, we've been using bors-ng and our developers were having trouble finding the corresponding CI build for their batched PRs. We run a lot concurrent builds, so this can be time consuming and very manual.

In this PR we add a Batch details page, which shows some basic information about the batch, as well as the batch's Status links (if present). This allows a developer to discover their corresponding CI build (`buildkite/shipit-test` in the attached screenshot).

<img width="1232" alt="Basic Batch details page" src="https://user-images.githubusercontent.com/1007983/71425956-25232e80-2660-11ea-85f8-a075aaa69f38.png">

To get to this page, we added a link from the Repository history tab. We weren't sure of the best way to add this, so we converted the existing "Batch" text into a "Batch X" hyperlink to the details page (see `Batch 4` in attached screenshot).

<img width="1232" alt="History tab containing link" src="https://user-images.githubusercontent.com/1007983/71425957-25232e80-2660-11ea-8146-baa1c49bbcde.png">

We have other ideas we'd like your feedback/thoughts on too. Maybe we can update the bors status url we send to the GitHub Status API to point to the new details page (instead of the History page)?