### PR TITLE
Use unique_constraint in changeset for link_patch_batch

### DIFF
--- a/lib/database/link_patch_batch.ex
+++ b/lib/database/link_patch_batch.ex
@@ -28,5 +28,8 @@ defmodule BorsNG.Database.LinkPatchBatch do
     struct
     |> cast(params, [:patch_id, :batch_id, :reviewer])
     |> validate_required([:patch_id, :batch_id, :reviewer])
+    |> unique_constraint(
+      :patch_id,
+      name: :link_patch_batch_patch_id_batch_id_index)
   end
 end


### PR DESCRIPTION
Recently, I saw few crashes are caused by this error 
```
{%Ecto.ConstraintError{
   constraint: "link_patch_batch_patch_id_batch_id_index",
   message: "constraint error when attempting to insert struct:\n\n    * unique: link_patch_batch_patch_id_batch_id_index\n\nIf you would like to convert this constraint into an error, please\ncall unique_constraint/3 in your changeset and define the proper\nconstraint name. The changeset has not defined any constraint.\n",
   type: :unique
 },
 [
   {Ecto.Repo.Schema, :"-constraints_to_errors/3-fun-1-", 4,
    [file: 'lib/ecto/repo/schema.ex', line: 574]},
   {Enum, :"-map/2-lists^map/1-0-", 2,
    [file: 'lib/enum.ex', line: 1327]},
   {Ecto.Repo.Schema, :constraints_to_errors, 3,
    [file: 'lib/ecto/repo/schema.ex', line: 559]},
   {Ecto.Repo.Schema, :"-do_insert/4-fun-1-", 14,
    [file: 'lib/ecto/repo/schema.ex', line: 222]},
   {Ecto.Repo.Schema, :"-wrap_in_transaction/6-fun-0-", 3,
    [file: 'lib/ecto/repo/schema.ex', line: 774]},
   {Ecto.Adapters.SQL, :"-do_transaction/3-fun-1-", 3,
    [file: 'lib/ecto/adapters/sql.ex', line: 576]},
   {DBConnection, :transaction_run, 4,
    [file: 'lib/db_connection.ex', line: 1283]},
   {DBConnection, :run_begin, 3,
    [file: 'lib/db_connection.ex', line: 1207]}
 ]} 
```
Not sure what is the root cause (may be race condition in somewhere, or duplicate messages?).
But I saw we use this `unique_constraint` in other places, to be consistent and make the error more clear, I think it's better to add it in link_patch_batch as well.