### PR TITLE
Add a configuration option for batch size limiting

### DIFF
--- a/lib/database/patch.ex
+++ b/lib/database/patch.ex
@@ -21,6 +21,7 @@ defmodule BorsNG.Database.Patch do
     field :commit, :string
     field :open, :boolean, default: true
     field :priority, :integer, default: 0
+    field :is_single, :boolean, default: false
     belongs_to :author, User
     timestamps()
   end
@@ -40,7 +41,8 @@ defmodule BorsNG.Database.Patch do
       :author_id,
       :open,
       :into_branch,
-      :priority])
+      :priority,
+      :is_single])
     |> unique_constraint(:pr_xref, name: :patches_pr_xref_index)
   end
 

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -91,6 +91,7 @@ defmodule BorsNG.Command do
     {:try, binary} |
     :try_cancel |
     {:activate_by, binary} |
+    {:set_is_single, integer()} |
     {:set_priority, integer()} |
     :activate |
     :deactivate |
@@ -130,6 +131,7 @@ defmodule BorsNG.Command do
 
   def parse_cmd("try-"), do: [:try_cancel]
   def parse_cmd("try" <> arguments), do: [{:try, arguments}]
+  def parse_cmd("r+ single" <> rest), do: parse_single_patch(rest) ++ [:activate]
   def parse_cmd("r+ p=" <> rest), do: parse_priority(rest) ++ [:activate]
   def parse_cmd("r+" <> _), do: [:activate]
   def parse_cmd("r-" <> _), do: [:deactivate]
@@ -289,6 +291,9 @@ defmodule BorsNG.Command do
     [{:set_priority, p}]
   end
 
+  def parse_single_patch("on" <> _), do: [{:set_is_single, true}]
+  def parse_single_patch("off" <> _), do: [{:set_is_single, false}]
+
   @doc """
   Given a populated struct, run everything.
   """
@@ -376,6 +381,10 @@ defmodule BorsNG.Command do
   def run(c, {:activate_by, username}) do
     batcher = Batcher.Registry.get(c.project.id)
     Batcher.reviewed(batcher, c.patch.id, username)
+  end
+  def run(c, {:set_is_single, is_single}) do
+    batcher = Batcher.Registry.get(c.project.id)
+    Batcher.set_is_single(batcher, c.patch.id, is_single)
   end
   def run(c, {:set_priority, priority}) do
     batcher = Batcher.Registry.get(c.project.id)

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -291,8 +291,14 @@ defmodule BorsNG.Command do
     [{:set_priority, p}]
   end
 
-  def parse_single_patch("on" <> _), do: [{:set_is_single, true}]
-  def parse_single_patch("off" <> _), do: [{:set_is_single, false}]
+  def parse_single_patch(binary) do
+    case String.trim(binary) do
+      "on" <> _ ->
+        [{:set_is_single, true}]
+      "off" <> _ ->
+        [{:set_is_single, false}]
+    end
+  end
 
   @doc """
   Given a populated struct, run everything.

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -131,6 +131,7 @@ defmodule BorsNG.Command do
 
   def parse_cmd("try-"), do: [:try_cancel]
   def parse_cmd("try" <> arguments), do: [{:try, arguments}]
+  def parse_cmd("single" <> rest), do: parse_single_patch(rest)
   def parse_cmd("r+ single" <> rest), do: parse_single_patch(rest) ++ [:activate]
   def parse_cmd("r+ p=" <> rest), do: parse_priority(rest) ++ [:activate]
   def parse_cmd("r+" <> _), do: [:activate]

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -869,13 +869,14 @@ defmodule BorsNG.Worker.Batcher do
   def get_new_batch(project_id, into_branch, priority, true) do
     {Repo.insert!(Batch.new(project_id, into_branch, priority)), true}
   end
+
   def get_new_batch(project_id, into_branch, priority, _force) do
     Batch
     |> where([b], b.project_id == ^project_id)
-    |> where([b], b.state == ^(:waiting))
+    |> where([b], b.state == ^:waiting)
     |> where([b], b.into_branch == ^into_branch)
     |> where([b], b.priority == ^priority)
-    |> order_by([b], [desc: b.updated_at])
+    |> order_by([b], desc: b.updated_at)
     |> Repo.all()
     |> Enum.reject(fn b ->
       Repo.all(LinkPatchBatch.from_batch(b.id))
@@ -884,7 +885,7 @@ defmodule BorsNG.Worker.Batcher do
       end)
     end)
     |> case do
-      [batch | _] -> {batch, false}
+      [batch] -> {batch, false}
       _ -> get_new_batch(project_id, into_branch, priority, true)
     end
   end

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -96,11 +96,9 @@ defmodule BorsNG.Worker.Batcher do
       nil -> nil
       %{is_single: ^is_single} -> nil
       patch ->
-        if is_single do
-          patch
-          |> Patch.changeset(%{is_single: true})
-          |> Repo.update!()
-        end
+        patch
+        |> Patch.changeset(%{is_single: is_single})
+        |> Repo.update!()
     end
 
     {:reply, :ok, project_id}

--- a/priv/repo/migrations/20200102093028_patch_is_single.exs
+++ b/priv/repo/migrations/20200102093028_patch_is_single.exs
@@ -4,5 +4,6 @@ defmodule BorsNG.Database.Repo.Migrations.PatchIsSingle do
   def change do
     alter table(:patches) do
       add :is_single, :boolean, default: false
+    end
   end
 end

--- a/priv/repo/migrations/20200102093028_patch_is_single.exs
+++ b/priv/repo/migrations/20200102093028_patch_is_single.exs
@@ -1,0 +1,8 @@
+defmodule BorsNG.Database.Repo.Migrations.PatchIsSingle do
+  use Ecto.Migration
+
+  def change do
+    alter table(:patches) do
+      add :is_single, :boolean, default: false
+  end
+end

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -55,6 +55,8 @@ defmodule BorsNG.CommandTest do
   test "accept single patch" do
     assert [{:set_is_single, true}, :activate] == Command.parse("bors r+ single on")
     assert [{:set_is_single, false}, :activate] == Command.parse("bors r+ single off")
+    assert [{:set_is_single, true}] == Command.parse("bors single on")
+    assert [{:set_is_single, false}] == Command.parse("bors single off")
   end
 
   test "do not parse single patch after try command" do

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -52,6 +52,16 @@ defmodule BorsNG.CommandTest do
     assert [:deactivate] == Command.parse("Bors merge-")
   end
 
+  test "accept single patch" do
+    assert [{:set_is_single, true}, :activate] == Command.parse("bors r+ single on")
+    assert [{:set_is_single, false}, :activate] == Command.parse("bors r+ single off")
+  end
+
+  test "do not parse single patch after try command" do
+    assert [{:try, " single on"}] == Command.parse("bors try single on")
+    assert [{:try, " single screwy"}] == Command.parse("bors try single screwy")
+  end
+
   test "accept priority" do
     assert [{:set_priority, 1}, :activate] == Command.parse("bors r+ p=1")
     assert [{:set_priority, 1}, :activate] == Command.parse("bors merge p=1")
@@ -458,7 +468,7 @@ defmodule BorsNG.CommandTest do
     assert [:activate] == Command.parse("popo merge")
     assert [:deactivate] == Command.parse("popo r-")
     assert [:deactivate] == Command.parse("popo merge-")
-    
+
     if old_env do
       System.put_env("COMMAND_TRIGGER", old_env)
     else


### PR DESCRIPTION
Fixes #205 

Took a while but I've implemented a 'r+ single on/off' command to have patches be batched by themselves only. However, this only occurs when patches are batched, either during bisect or when a patch is newly reviewed. I couldn't figure out how to make this apply for patches that are already in a running/waiting batch.

Additionally, I wasn't too sure whether ensuring that bisect honors the single patch option was a good idea or not. I'm thinking that it's unnecessary because if a batch fails, the singled patch will either become singled through enough bisections or will successfully merge into master without any issues. I implemented it just in case there was a case I have not thought of but please let me know if it can be removed. 

I've added a few test cases to test for the following:

- patches that are newly reviewed and singled are batched alone and not into existing waiting batches
- patches that are newly reviewed are not added to batches containing singled patches
- the bisecting process honors single patches