### PR TITLE
Fix crash that caused by multiple "bors merge" commands before PR statuses pass

### DIFF
--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -766,6 +766,54 @@ defmodule BorsNG.Worker.BatcherTest do
       }}
   end
 
+  test "Multiple polls on a same pending (waiting) PR status. Then accept after that CI succeeds.", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{1 => []},
+        statuses: %{"Z" => %{"cn" => :running}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }})
+    patch = %Patch{
+      project_id: proj.id,
+      pr_xref: 1,
+      commit: "Z",
+      into_branch: "master"}
+    |> Repo.insert!()
+    Batcher.handle_cast({:reviewed, patch.id, "rvr"}, proj.id)
+    state = GitHub.ServerMock.get_state()
+    assert state == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{
+          1 => [":clock1: Waiting for PR status (Github check) to be set, probably by CI. Bors will automatically try to run when all required PR statuses are set."]},
+        statuses: %{"Z" => %{"cn" => :running}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }}
+    path = [{{:installation, 91}, 14}, :statuses, "Z"]
+    GitHub.ServerMock.put_state(update_in(GitHub.ServerMock.get_state,
+      path,
+      &(Map.put(&1, "cn", :ok))))
+    Batcher.handle_info({:prerun_poll, 1000, {"rvr", patch}}, proj.id)
+    Batcher.handle_info({:prerun_poll, 1000, {"rvr", patch}}, proj.id)
+    Batcher.handle_info({:prerun_poll, 1000, {"rvr", patch}}, proj.id)
+    state = GitHub.ServerMock.get_state()
+    assert state == %{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{
+          1 => [":clock1: Waiting for PR status (Github check) to be set, probably by CI. Bors will automatically try to run when all required PR statuses are set."]},
+        statuses: %{"Z" => %{"cn" => :ok, "bors" => :running}},
+        files: %{"Z" => %{"bors.toml" =>
+          ~s/status = [ "ci" ]\npr_status = [ "cn" ]/}},
+      }}
+  end
+
   test "rejects a patch with a requested changes", %{proj: proj} do
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{


### PR DESCRIPTION
## Context
We found this bug when people type "bors merge" multiple times before the PR statuses pass, and it causes bors to crash.

It is common for our developers to initiate a `bors merge` before all PR statuses have passed. Sometimes, they will invoke a second (or third) `bors merge` command on the same PR, whilst bors is still polling from the initial command.

When the statuses do pass, then we observe the following crash:
```
{%Ecto.InvalidChangesetError{
   action: :insert,
   changeset: #Ecto.Changeset<
     action: :insert,
     changes: %{
       batch_id: 10,
       patch_id: 44,
       reviewer: "some-dev"
     },
     errors: [patch_id: {"has already been taken", []}],
     data: #BorsNG.Database.LinkPatchBatch<>,
     valid?: false
   >
 },
 [
   {Ecto.Repo.Schema, :insert!, 4,
    [file: 'lib/ecto/repo/schema.ex', line: 128]},
   {BorsNG.Worker.Batcher, :run, 2,
    [file: 'lib/worker/batcher.ex', line: 245]},
   {BorsNG.Worker.Batcher, :handle_info, 2,
    [file: 'lib/worker/batcher.ex', line: 199]},
   {:gen_server, :try_dispatch, 4,
    [file: 'gen_server.erl', line: 637]},
   {:gen_server, :handle_msg, 6,
    [file: 'gen_server.erl', line: 711]},
   {:proc_lib, :init_p_do_apply, 3,
    [file: 'proc_lib.erl', line: 249]}
 ]}
```

We believe this is because the :prerun_poll loop is executing multiple times concurrently.

## Steps to reproduce in dev
We were able to reproduce the error locally (via `iex -S mix phx.server`) by running the code steps described in  [steps_to_reproduce.md.txt](https://github.com/bors-ng/bors-ng/files/4021099/steps_to_reproduce.md.txt)

## Proposed fix
Inside of the `handle_info({:prerun_poll, timeout, args}, proj_id)` loop, we do an additional check, to see if the patch is already running. This means the second (, third, etc) loops can finish gracefully and not invoking `Batcher.run`.

We were unable to do the check in `do_handle_cast({:reviewed, patch_id, reviewer}, _project_id)`, because we do not know a way to check if a `:prerun_poll` loop is running in elixir.

## Questions
- is there way know if `:prerun_poll` is running when we enter `do_handle_cast({:reviewed, patch_id, reviewer}, _project_id)`?
- is there a more elegant way to fix this issue?