### PR TITLE
Isolate unmergeable PRs when a batch fails because of conflict

### DIFF
--- a/lib/github/github/friendly.ex
+++ b/lib/github/github/friendly.ex
@@ -161,7 +161,8 @@ defmodule BorsNG.GitHub.FriendlyMock do
              head_sha: sha,
              head_ref: ref,
              body: body,
-             user: @def_user}
+             user: @def_user,
+             mergeable: true}
     update_mock([:pulls], &(Map.put(&1, number, pr)))
     update_mock([:pr_commits], &(Map.put(&1, number, [])))
     update_mock([:comments], &(Map.put(&1, number, [])))
@@ -260,7 +261,8 @@ defmodule BorsNG.GitHub.FriendlyMock do
                      base_ref: base_ref,
                      head_sha: head_sha,
                      body: body,
-                     user: user}) do
+                     user: user,
+                     mergeable: mergeable}) do
     %{
     "number" => number,
     "title" => title,
@@ -281,6 +283,7 @@ defmodule BorsNG.GitHub.FriendlyMock do
     },
     "user" => user,
     "merged_at" => "some non-nul time :)",
+    "mergeable" => mergeable,
     }
   end
 

--- a/lib/github/github/pr.ex
+++ b/lib/github/github/pr.ex
@@ -12,6 +12,7 @@ defmodule BorsNG.GitHub.Pr do
     base_ref: bitstring,
     head_sha: bitstring,
     user: BorsNG.GitHub.User.t,
+    mergeable: boolean | nil,
   }
   defstruct(
     number: 0,
@@ -24,7 +25,8 @@ defmodule BorsNG.GitHub.Pr do
     head_ref: "",
     head_repo_id: 0,
     base_repo_id: 0,
-    merged: false
+    merged: false,
+    mergeable: nil
     )
 
   @doc """
@@ -64,6 +66,7 @@ defmodule BorsNG.GitHub.Pr do
       "avatar_url" => user_avatar_url,
     },
     "merged_at" => merged_at,
+    "mergeable" => mergeable,
   }) when is_integer(number) do
     {:ok, %BorsNG.GitHub.Pr{
       number: number,
@@ -89,7 +92,8 @@ defmodule BorsNG.GitHub.Pr do
         login: user_login,
         avatar_url: user_avatar_url,
       },
-      merged: not is_nil merged_at
+      merged: (not is_nil merged_at),
+      mergeable: mergeable
     }}
   end
 

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -455,9 +455,7 @@ defmodule BorsNG.Worker.Batcher do
     repo_conn = get_repo_conn(project)
     patches = Enum.map(patch_links, &(&1.patch))
     state = Divider.split_batch_with_conflicts(patch_links, batch)
-    if state == :retrying do
-      poll_after_delay(project)
-    end
+    poll_after_delay(project)
 
     send_message(repo_conn, patches, {:conflict, state})
 

--- a/lib/worker/batcher/divider.ex
+++ b/lib/worker/batcher/divider.ex
@@ -1,0 +1,96 @@
+defmodule BorsNG.Worker.Batcher.Divider do
+
+  alias BorsNG.Database.Repo
+  alias BorsNG.Database.Batch
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.LinkPatchBatch
+  alias BorsNG.GitHub
+
+  def split_batch(patch_links, %Batch{project: project, into_branch: into}) do
+    count = Enum.count(patch_links)
+    if count > 1 do
+      bisect(patch_links, project.id, into)
+      :retrying
+    else
+      :failed
+    end
+  end
+
+  def split_batch_with_conflicts(patch_links, %Batch{project: project, into_branch: into}) do
+    repo_conn = get_repo_conn(project)
+
+    # if mergeable 0 and unmergeable = 1 -> fail no retry
+    #              0                   2+  create single batches for unmergeable patches
+    #              1                   0  impossible
+    #              1                   1+ create single batches for both
+    #              2+                  0  bisect for mergeable patches
+    #              2+                  1+ one batch for mergeable patches, create single batches for unmergeable patches
+    # Create batches for unmergeable patches first, so they will be picked up first and fail first.
+    case isolate_unmergeable_patch_links(patch_links, repo_conn) do
+      {[], [_]} ->
+        :failed
+
+      {[], multiple_unmergeable} ->
+        Enum.each multiple_unmergeable, fn patch_link ->
+          clone_batch([patch_link], project.id, into)
+        end
+        :retrying
+
+      {[single_mergeable], multiple_unmergeable} ->
+        Enum.each multiple_unmergeable, fn patch_link ->
+          clone_batch([patch_link], project.id, into)
+        end
+        clone_batch([single_mergeable], project.id, into)
+        :retrying
+
+      {multiple_mergeable, []} ->
+        bisect(multiple_mergeable, project.id, into)
+        :retrying
+
+      {multiple_mergeable, multiple_unmergeable} ->
+        Enum.each multiple_unmergeable, fn patch_link ->
+          clone_batch([patch_link], project.id, into)
+        end
+        clone_batch(multiple_mergeable, project.id, into)
+        :retrying
+    end
+  end
+
+  def clone_batch(patch_links, project_id, into_branch) do
+    batch = Repo.insert!(Batch.new(project_id, into_branch))
+    patch_links
+    |> Enum.map(&%{
+      batch_id: batch.id,
+      patch_id: &1.patch_id,
+      reviewer: &1.reviewer})
+    |> Enum.map(&LinkPatchBatch.changeset(%LinkPatchBatch{}, &1))
+    |> Enum.each(&Repo.insert!/1)
+    batch
+  end
+
+  defp bisect(patch_links, project_id, into) do
+    count = Enum.count(patch_links)
+
+    {lo, hi} = Enum.split(patch_links, div(count, 2))
+    clone_batch(lo, project_id, into)
+    clone_batch(hi, project_id, into)
+  end
+
+  defp isolate_unmergeable_patch_links(patch_links, repo_conn) do
+    patch_link_map =
+      patch_links
+      |> Enum.group_by(fn patch_link -> is_patch_mergeable(patch_link.patch, repo_conn) end)
+
+    {patch_link_map[true]||[], patch_link_map[false]||[]}
+  end
+
+  defp is_patch_mergeable(patch, repo_conn) do
+    pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
+    pr.mergeable == true || pr.mergeable == nil
+  end
+
+  @spec get_repo_conn(%Project{}) :: {{:installation, number}, number}
+  defp get_repo_conn(project) do
+    Project.installation_connection(project.repo_xref, Repo)
+  end
+end

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -1420,7 +1420,7 @@ defmodule BorsNG.Worker.BatcherTest do
              }}
   end
 
-  test "merge conflict", %{proj: proj} do
+  test "merge conflict with master", %{proj: proj} do
     # Projects are created with a "waiting" state
     GitHub.ServerMock.put_state(%{
       {{:installation, 91}, 14} => %{
@@ -1428,6 +1428,21 @@ defmodule BorsNG.Worker.BatcherTest do
         commits: %{},
         comments: %{1 => []},
         statuses: %{"iniN" => %{}},
+        pulls: %{
+          1 => %Pr{
+            number: 1,
+            title: "Test",
+            body: "Mess",
+            state: :open,
+            base_ref: "master",
+            head_sha: "00000001",
+            head_ref: "update",
+            base_repo_id: 14,
+            head_repo_id: 14,
+            merged: false,
+            mergeable: false,
+          }
+        },
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},
         pr_commits: %{1 => [
           %GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"},
@@ -1463,6 +1478,21 @@ defmodule BorsNG.Worker.BatcherTest do
           "ini" => %{commit_message: "[ci skip][skip ci][skip netlify]", parents: ["ini"]}},
         comments: %{1 => ["# Merge conflict"]},
         statuses: %{"N" => %{"bors" => :error}, "iniN" => %{}},
+        pulls: %{
+          1 => %Pr{
+            number: 1,
+            title: "Test",
+            body: "Mess",
+            state: :open,
+            base_ref: "master",
+            head_sha: "00000001",
+            head_ref: "update",
+            base_repo_id: 14,
+            head_repo_id: 14,
+            merged: false,
+            mergeable: false,
+          }
+        },
         files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},
         pr_commits: %{1 => [
           %GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"},

--- a/test/batcher/divider_test.exs
+++ b/test/batcher/divider_test.exs
@@ -166,11 +166,16 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
 
 
       assert result == :retrying
-      batches = Repo.all Batch, project_id: proj.id
-      assert (Enum.count batches) == 3 # original, plus new batch for patch1, plus new batch for patch2
 
-      # TODO: check batch 2 contains link1
-      # TODO: check batch 3 contains link2
+      [original_batch, new_batch1, new_batch2] = Repo.all(from b in Batch, where: b.project_id == ^proj.id, order_by: [asc: b.id])
+
+      assert batch.id == original_batch.id
+
+      links_for_new_batch1 =  Repo.all(from l in LinkPatchBatch, where: l.batch_id == ^new_batch1.id)
+      assert Enum.map(links_for_new_batch1, &(&1.patch_id)) == [patch1.id]
+
+      links_for_new_batch2 =  Repo.all(from l in LinkPatchBatch, where: l.batch_id == ^new_batch2.id)
+      assert Enum.map(links_for_new_batch2, &(&1.patch_id)) == [patch2.id]
     end
 
     test "multiple PRs without conflicts with master are retried via a bisect", %{proj: proj, batch: batch, patch1: patch1, patch2: patch2, patch3: patch3, patch4: patch4} do
@@ -273,10 +278,16 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
 
 
       assert result == :retrying
-      batches = Repo.all Batch, project_id: proj.id
-      assert (Enum.count batches) == 3 # original, plus new batch for patch1, plus new batch for patch2
-      # TODO: check batch 2 contains link1 and link2
-      # TODO: check batch 3 contains link3 and link4
+
+      [original_batch, new_batch1, new_batch2] = Repo.all(from b in Batch, where: b.project_id == ^proj.id, order_by: [asc: b.id])
+
+      assert batch.id == original_batch.id
+
+      links_for_new_batch1 =  Repo.all(from l in LinkPatchBatch, where: l.batch_id == ^new_batch1.id)
+      assert Enum.map(links_for_new_batch1, &(&1.patch_id)) == [patch1.id, patch2.id]
+
+      links_for_new_batch2 =  Repo.all(from l in LinkPatchBatch, where: l.batch_id == ^new_batch2.id)
+      assert Enum.map(links_for_new_batch2, &(&1.patch_id)) == [patch3.id, patch4.id]
     end
 
     test "multiple PRs with and without conflicts with master", %{proj: proj, batch: batch, patch1: patch1, patch2: patch2, patch3: patch3, patch4: patch4} do
@@ -377,13 +388,20 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
 
       result = Divider.split_batch_with_conflicts([link1, link2, link3, link4], batch)
 
-
       assert result == :retrying
-      batches = Repo.all Batch, project_id: proj.id
-      assert (Enum.count batches) == 4 # original
-      # TODO: check batch 2 contains link1
-      # TODO: check batch 3 contains link2
-      # TODO: check batch 4 contains link3 and link4
+
+      [original_batch, new_batch1, new_batch2, new_batch3] = Repo.all(from b in Batch, where: b.project_id == ^proj.id, order_by: [asc: b.id])
+
+      assert batch.id == original_batch.id
+
+      links_for_new_batch1 =  Repo.all(from l in LinkPatchBatch, where: l.batch_id == ^new_batch1.id)
+      assert Enum.map(links_for_new_batch1, &(&1.patch_id)) == [patch1.id]
+
+      links_for_new_batch2 =  Repo.all(from l in LinkPatchBatch, where: l.batch_id == ^new_batch2.id)
+      assert Enum.map(links_for_new_batch2, &(&1.patch_id)) == [patch2.id]
+
+      links_for_new_batch3 =  Repo.all(from l in LinkPatchBatch, where: l.batch_id == ^new_batch3.id)
+      assert Enum.map(links_for_new_batch3, &(&1.patch_id)) == [patch3.id, patch4.id]
     end
 
     test "single PR that with unknown mergeable value is retried", %{proj: proj, batch: batch, patch1: patch} do
@@ -426,9 +444,13 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
 
 
       assert result == :retrying
-      batches = Repo.all Batch, project_id: proj.id
-      assert (Enum.count batches) == 2
-      # TODO: assert batch 2 contains link1
+
+      [original_batch, new_batch1] = Repo.all(from b in Batch, where: b.project_id == ^proj.id, order_by: [asc: b.id])
+
+      assert batch.id == original_batch.id
+
+      links_for_new_batch1 =  Repo.all(from l in LinkPatchBatch, where: l.batch_id == ^new_batch1.id)
+      assert Enum.map(links_for_new_batch1, &(&1.patch_id)) == [patch.id]
     end
 
   end

--- a/test/batcher/divider_test.exs
+++ b/test/batcher/divider_test.exs
@@ -59,6 +59,14 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
     {:ok, inst: inst, proj: proj, batch: batch, patch1: patch1, patch2: patch2, patch3: patch3, patch4: patch4}
   end
 
+  defp create_link(patch, batch) do
+    link = %LinkPatchBatch{patch_id: patch.id, batch_id: batch.id, reviewer: "some_user"}
+            |> Repo.insert!()
+
+    # manually preload
+    %LinkPatchBatch{link | patch: patch}
+  end
+
   describe "split_batch_with_conflicts" do
 
     test "single PR that conflicts with master fails", %{proj: proj, batch: batch, patch1: patch} do
@@ -92,9 +100,7 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
         :merge_conflict => 0,
       })
 
-      link = %LinkPatchBatch{patch_id: patch.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link = %LinkPatchBatch{link | patch: patch} # fake the preloading of our test records
+      link = create_link(patch, batch)
 
 
       result = Divider.split_batch_with_conflicts([link], batch)
@@ -153,13 +159,8 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
         :merge_conflict => 0,
       })
 
-      link1 = %LinkPatchBatch{patch_id: patch1.id, batch_id: batch.id, reviewer: "some_user"}
-             |> Repo.insert!()
-      link1 = %LinkPatchBatch{link1 | patch: patch1} # fake the preloading of our test records
-
-      link2 = %LinkPatchBatch{patch_id: patch2.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link2 = %LinkPatchBatch{link2 | patch: patch2} # fake the preloading of our test records
+      link1 = create_link(patch1, batch)
+      link2 = create_link(patch2, batch)
 
 
       result = Divider.split_batch_with_conflicts([link1, link2], batch)
@@ -257,22 +258,10 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
         :merge_conflict => 0,
       })
 
-      link1 = %LinkPatchBatch{patch_id: patch1.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link1 = %LinkPatchBatch{link1 | patch: patch1} # fake the preloading of our test records
-
-      link2 = %LinkPatchBatch{patch_id: patch2.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link2 = %LinkPatchBatch{link2 | patch: patch2} # fake the preloading of our test records
-
-      link3 = %LinkPatchBatch{patch_id: patch3.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link3 = %LinkPatchBatch{link3 | patch: patch3} # fake the preloading of our test records
-
-      link4 = %LinkPatchBatch{patch_id: patch4.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link4 = %LinkPatchBatch{link4 | patch: patch4} # fake the preloading of our test records
-
+      link1 = create_link(patch1, batch)
+      link2 = create_link(patch2, batch)
+      link3 = create_link(patch3, batch)
+      link4 = create_link(patch4, batch)
 
       result = Divider.split_batch_with_conflicts([link1, link2, link3, link4], batch)
 
@@ -369,21 +358,10 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
         :merge_conflict => 0,
       })
 
-      link1 = %LinkPatchBatch{patch_id: patch1.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link1 = %LinkPatchBatch{link1 | patch: patch1} # fake the preloading of our test records
-
-      link2 = %LinkPatchBatch{patch_id: patch2.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link2 = %LinkPatchBatch{link2 | patch: patch2} # fake the preloading of our test records
-
-      link3 = %LinkPatchBatch{patch_id: patch3.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link3 = %LinkPatchBatch{link3 | patch: patch3} # fake the preloading of our test records
-
-      link4 = %LinkPatchBatch{patch_id: patch4.id, batch_id: batch.id, reviewer: "some_user"}
-              |> Repo.insert!()
-      link4 = %LinkPatchBatch{link4 | patch: patch4} # fake the preloading of our test records
+      link1 = create_link(patch1, batch)
+      link2 = create_link(patch2, batch)
+      link3 = create_link(patch3, batch)
+      link4 = create_link(patch4, batch)
 
 
       result = Divider.split_batch_with_conflicts([link1, link2, link3, link4], batch)
@@ -435,9 +413,7 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
         :merge_conflict => 0,
       })
 
-      link = %LinkPatchBatch{patch_id: patch.id, batch_id: batch.id, reviewer: "some_user"}
-             |> Repo.insert!()
-      link = %LinkPatchBatch{link | patch: patch} # fake the preloading of our test records
+      link = create_link(patch, batch)
 
 
       result = Divider.split_batch_with_conflicts([link], batch)

--- a/test/batcher/divider_test.exs
+++ b/test/batcher/divider_test.exs
@@ -1,0 +1,435 @@
+defmodule BorsNG.Worker.Batcher.DividerTest do
+  use BorsNG.Worker.TestCase
+
+  alias BorsNG.Worker.Batcher
+  alias BorsNG.Worker.Batcher.Divider
+  alias BorsNG.Database.Batch
+  alias BorsNG.Database.Installation
+  alias BorsNG.Database.LinkPatchBatch
+  alias BorsNG.Database.Patch
+  alias BorsNG.Database.Project
+  alias BorsNG.Database.Repo
+  alias BorsNG.GitHub.Pr
+  alias BorsNG.Database.Status
+  alias BorsNG.GitHub
+
+  import Ecto.Query
+
+  setup do
+    inst = %Installation{installation_xref: 91}
+           |> Repo.insert!()
+    proj = %Project{
+             installation_id: inst.id,
+             repo_xref: 14,
+             staging_branch: "staging"}
+           |> Repo.insert!()
+    batch = %Batch{
+              project_id: proj.id,
+              state: :running,
+              into_branch: "master"}
+            |> Repo.insert!()
+    batch = %Batch{batch | project: proj} # fake the preloading of our test records
+    patch1 = %Patch{
+               project_id: proj.id,
+               pr_xref: 1,
+               commit: "N",
+               into_branch: "master"}
+             |> Repo.insert!()
+
+    patch2 = %Patch{
+               project_id: proj.id,
+               pr_xref: 2,
+               commit: "N",
+               into_branch: "master"}
+             |> Repo.insert!()
+
+    patch3 = %Patch{
+               project_id: proj.id,
+               pr_xref: 3,
+               commit: "N",
+               into_branch: "master"}
+             |> Repo.insert!()
+
+    patch4 = %Patch{
+               project_id: proj.id,
+               pr_xref: 4,
+               commit: "N",
+               into_branch: "master"}
+             |> Repo.insert!()
+    {:ok, inst: inst, proj: proj, batch: batch, patch1: patch1, patch2: patch2, patch3: patch3, patch4: patch4}
+  end
+
+  describe "split_batch_with_conflicts" do
+
+    test "single PR that conflicts with master fails", %{proj: proj, batch: batch, patch1: patch} do
+      # Projects are created with a "waiting" state
+      GitHub.ServerMock.put_state(%{
+        {{:installation, 91}, 14} => %{
+          branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+          commits: %{},
+          comments: %{1 => []},
+          statuses: %{"iniN" => %{}},
+          pulls: %{
+            1 => %Pr{
+              number: 1,
+              title: "Test",
+              body: "Mess",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000001",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: false,
+            }
+          },
+          files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},
+          pr_commits: %{1 => [
+                          %GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"},
+          ]},
+        },
+        :merge_conflict => 0,
+      })
+
+      link = %LinkPatchBatch{patch_id: patch.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link = %LinkPatchBatch{link | patch: patch} # fake the preloading of our test records
+
+
+      result = Divider.split_batch_with_conflicts([link], batch)
+
+
+      assert result == :failed
+      batches = Repo.all Batch, project_id: proj.id
+      assert (Enum.count batches) == 1
+    end
+
+    test "multiple PRs that conflicts with master are retried individually", %{proj: proj, batch: batch, patch1: patch1, patch2: patch2} do
+      # Projects are created with a "waiting" state
+      GitHub.ServerMock.put_state(%{
+        {{:installation, 91}, 14} => %{
+          branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+          commits: %{},
+          comments: %{1 => [], 2 => []},
+          statuses: %{"iniN" => %{}},
+          pulls: %{
+            1 => %Pr{
+              number: 1,
+              title: "Test",
+              body: "Mess",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000001",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: false,
+            },
+            2 => %Pr{
+              number: 1,
+              title: "Test 2",
+              body: "Mess 2",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000002",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: false,
+            }
+          },
+          files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},
+          pr_commits: %{
+            1 => [
+              %GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"},
+            ],
+            2 => [
+              %GitHub.Commit{sha: "5678", author_name: "a", author_email: "e"},
+            ]},
+        },
+        :merge_conflict => 0,
+      })
+
+      link1 = %LinkPatchBatch{patch_id: patch1.id, batch_id: batch.id, reviewer: "some_user"}
+             |> Repo.insert!()
+      link1 = %LinkPatchBatch{link1 | patch: patch1} # fake the preloading of our test records
+
+      link2 = %LinkPatchBatch{patch_id: patch2.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link2 = %LinkPatchBatch{link2 | patch: patch2} # fake the preloading of our test records
+
+
+      result = Divider.split_batch_with_conflicts([link1, link2], batch)
+
+
+      assert result == :retrying
+      batches = Repo.all Batch, project_id: proj.id
+      assert (Enum.count batches) == 3 # original, plus new batch for patch1, plus new batch for patch2
+
+      # TODO: check batch 2 contains link1
+      # TODO: check batch 3 contains link2
+    end
+
+    test "multiple PRs without conflicts with master are retried via a bisect", %{proj: proj, batch: batch, patch1: patch1, patch2: patch2, patch3: patch3, patch4: patch4} do
+      GitHub.ServerMock.put_state(%{
+        {{:installation, 91}, 14} => %{
+          branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+          commits: %{},
+          comments: %{1 => [], 2 => [], 3 => [], 4 => []},
+          statuses: %{"iniN" => %{}},
+          pulls: %{
+            1 => %Pr{
+              number: 1,
+              title: "Test",
+              body: "Mess",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000001",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: true,
+            },
+            2 => %Pr{
+              number: 1,
+              title: "Test 2",
+              body: "Mess 2",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000002",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: true,
+            },
+            3 => %Pr{
+              number: 1,
+              title: "Test 3",
+              body: "Mess 3",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000003",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: true,
+            },
+            4 => %Pr{
+              number: 1,
+              title: "Test 4",
+              body: "Mess 4",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000004",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: true,
+            }
+          },
+          files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},
+          pr_commits: %{
+            1 => [
+              %GitHub.Commit{sha: "0001", author_name: "a", author_email: "e"},
+            ],
+            2 => [
+              %GitHub.Commit{sha: "0002", author_name: "a", author_email: "e"},
+            ],
+            3 => [
+              %GitHub.Commit{sha: "0003", author_name: "a", author_email: "e"},
+            ],
+            4 => [
+              %GitHub.Commit{sha: "0004", author_name: "a", author_email: "e"},
+            ]},
+        },
+        :merge_conflict => 0,
+      })
+
+      link1 = %LinkPatchBatch{patch_id: patch1.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link1 = %LinkPatchBatch{link1 | patch: patch1} # fake the preloading of our test records
+
+      link2 = %LinkPatchBatch{patch_id: patch2.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link2 = %LinkPatchBatch{link2 | patch: patch2} # fake the preloading of our test records
+
+      link3 = %LinkPatchBatch{patch_id: patch3.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link3 = %LinkPatchBatch{link3 | patch: patch3} # fake the preloading of our test records
+
+      link4 = %LinkPatchBatch{patch_id: patch4.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link4 = %LinkPatchBatch{link4 | patch: patch4} # fake the preloading of our test records
+
+
+      result = Divider.split_batch_with_conflicts([link1, link2, link3, link4], batch)
+
+
+      assert result == :retrying
+      batches = Repo.all Batch, project_id: proj.id
+      assert (Enum.count batches) == 3 # original, plus new batch for patch1, plus new batch for patch2
+      # TODO: check batch 2 contains link1 and link2
+      # TODO: check batch 3 contains link3 and link4
+    end
+
+    test "multiple PRs with and without conflicts with master", %{proj: proj, batch: batch, patch1: patch1, patch2: patch2, patch3: patch3, patch4: patch4} do
+      GitHub.ServerMock.put_state(%{
+        {{:installation, 91}, 14} => %{
+          branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+          commits: %{},
+          comments: %{1 => [], 2 => [], 3 => [], 4 => []},
+          statuses: %{"iniN" => %{}},
+          pulls: %{
+            1 => %Pr{
+              number: 1,
+              title: "Test",
+              body: "Mess",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000001",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: false,
+            },
+            2 => %Pr{
+              number: 1,
+              title: "Test 2",
+              body: "Mess 2",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000002",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: false,
+            },
+            3 => %Pr{
+              number: 1,
+              title: "Test 3",
+              body: "Mess 3",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000003",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: true,
+            },
+            4 => %Pr{
+              number: 1,
+              title: "Test 4",
+              body: "Mess 4",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000004",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: true,
+            }
+          },
+          files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},
+          pr_commits: %{
+            1 => [
+              %GitHub.Commit{sha: "0001", author_name: "a", author_email: "e"},
+            ],
+            2 => [
+              %GitHub.Commit{sha: "0002", author_name: "a", author_email: "e"},
+            ],
+            3 => [
+              %GitHub.Commit{sha: "0003", author_name: "a", author_email: "e"},
+            ],
+            4 => [
+              %GitHub.Commit{sha: "0004", author_name: "a", author_email: "e"},
+            ]},
+        },
+        :merge_conflict => 0,
+      })
+
+      link1 = %LinkPatchBatch{patch_id: patch1.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link1 = %LinkPatchBatch{link1 | patch: patch1} # fake the preloading of our test records
+
+      link2 = %LinkPatchBatch{patch_id: patch2.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link2 = %LinkPatchBatch{link2 | patch: patch2} # fake the preloading of our test records
+
+      link3 = %LinkPatchBatch{patch_id: patch3.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link3 = %LinkPatchBatch{link3 | patch: patch3} # fake the preloading of our test records
+
+      link4 = %LinkPatchBatch{patch_id: patch4.id, batch_id: batch.id, reviewer: "some_user"}
+              |> Repo.insert!()
+      link4 = %LinkPatchBatch{link4 | patch: patch4} # fake the preloading of our test records
+
+
+      result = Divider.split_batch_with_conflicts([link1, link2, link3, link4], batch)
+
+
+      assert result == :retrying
+      batches = Repo.all Batch, project_id: proj.id
+      assert (Enum.count batches) == 4 # original
+      # TODO: check batch 2 contains link1
+      # TODO: check batch 3 contains link2
+      # TODO: check batch 4 contains link3 and link4
+    end
+
+    test "single PR that with unknown mergeable value is retried", %{proj: proj, batch: batch, patch1: patch} do
+      # Projects are created with a "waiting" state
+      GitHub.ServerMock.put_state(%{
+        {{:installation, 91}, 14} => %{
+          branches: %{"master" => "ini", "staging" => "", "staging.tmp" => ""},
+          commits: %{},
+          comments: %{1 => []},
+          statuses: %{"iniN" => %{}},
+          pulls: %{
+            1 => %Pr{
+              number: 1,
+              title: "Test",
+              body: "Mess",
+              state: :open,
+              base_ref: "master",
+              head_sha: "00000001",
+              head_ref: "update",
+              base_repo_id: 14,
+              head_repo_id: 14,
+              merged: false,
+              mergeable: nil,
+            }
+          },
+          files: %{"staging.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}},
+          pr_commits: %{1 => [
+                          %GitHub.Commit{sha: "1234", author_name: "a", author_email: "e"},
+          ]},
+        },
+        :merge_conflict => 0,
+      })
+
+      link = %LinkPatchBatch{patch_id: patch.id, batch_id: batch.id, reviewer: "some_user"}
+             |> Repo.insert!()
+      link = %LinkPatchBatch{link | patch: patch} # fake the preloading of our test records
+
+
+      result = Divider.split_batch_with_conflicts([link], batch)
+
+
+      assert result == :retrying
+      batches = Repo.all Batch, project_id: proj.id
+      assert (Enum.count batches) == 2
+      # TODO: assert batch 2 contains link1
+    end
+
+  end
+end

--- a/test/batcher/divider_test.exs
+++ b/test/batcher/divider_test.exs
@@ -1,7 +1,6 @@
 defmodule BorsNG.Worker.Batcher.DividerTest do
   use BorsNG.Worker.TestCase
 
-  alias BorsNG.Worker.Batcher
   alias BorsNG.Worker.Batcher.Divider
   alias BorsNG.Database.Batch
   alias BorsNG.Database.Installation
@@ -10,7 +9,6 @@ defmodule BorsNG.Worker.Batcher.DividerTest do
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
   alias BorsNG.GitHub.Pr
-  alias BorsNG.Database.Status
   alias BorsNG.GitHub
 
   import Ecto.Query

--- a/test/controllers/webhook_controller_test.exs
+++ b/test/controllers/webhook_controller_test.exs
@@ -49,6 +49,7 @@ defmodule BorsNG.WebhookControllerTest do
           },
         },
         "merged_at" => nil,
+        "mergeable" => true,
         "user" => %{
           "id" => 23,
           "login" => "ghost",
@@ -88,6 +89,7 @@ defmodule BorsNG.WebhookControllerTest do
           },
         },
         "merged_at" => nil,
+        "mergeable" => true,
         "user" => %{
           "id" => 23,
           "login" => "ghost",
@@ -162,6 +164,7 @@ defmodule BorsNG.WebhookControllerTest do
           },
         },
         "merged_at" => "time",
+        "mergeable" => true,
         "user" => %{
           "id" => 23,
           "login" => "ghost",


### PR DESCRIPTION
## Context
In our deployment of bors, we see numerous conflicts within batches. Batches often contain PRs that are not mergeable with the target branch. These batches will sit in `:waiting` state, collecting other PRs that have been added to the merge queue. These unmergeable PRs will remain in the merge queue, creating failures in many batches and slowing the progress of mergeable PRs through the merge queue.

This problem was briefly mentioned in [this forum post](https://forum.bors.tech/t/limiting-the-scope-of-merge-failures-in-batches/421).

## Goal
We want to remove unmergeable PRs from the merge queue as soon as possible. We want to give the authors quicker feedback that they need to manually rebase their branch. Isolating unmergeable PRs to their own batches means when they do fail, they will not be bisected/retried.

## Approach
Currently bors performs a bisect in a merge conflict situation to identify the problematic PRs. We think that by using additional information (the mergeability of PRs with the target branch), we can perform more optimal identification.

## Solution
When a batch fails due to a merge conflict, we isolate any PRs that are unmergeable, and put them into their own individual batches. The goal is that these unmergeable batches will run immediately (after the current batch finishes) and fail fast. This contains the failure to only this PR, and does not affect other PRs.

We use the GitHub API to determine mergeability (using the `mergeable` field referenced [here](https://developer.github.com/v3/pulls/#response-1)).

## Example
Here is an example of the proposed solution. 

![Screen Shot 2020-01-09 at 5 33 29 PM](https://user-images.githubusercontent.com/1007983/72116054-3af24e00-3306-11ea-9ad0-7fdf5238ccb7.png)

The timeline of events
1. PRs 97, 93, 91, 90, and 89 are all added to the merge queue. 97, 92, and 89 have merge conflicts with the target branch and are unmergeable.
1. The 5 PRs enter Batch 138
1. Batch 138 fails due to a merge conflict
1. bors first determines that PRs 97, 92, and 89 are unmergeable and creates individual batches for each of them (Batch 139, Batch 140, and Batch 141)
1. then bors creates a batch containing the remaining mergeable PRs 90 and 91 (Batch 142)
1. bors runs Batch 139 and fails due to a merge conflict. This repeated for Batches 140 and 141 also.
1. bors runs Batch 142 and succeeds.


## Possible extensions
- fail unmergeable batches immediately (skip the queue by creating with state = `:failed`)?
- bump priority of unmergeable batches?
- perform best effort merging  when there are conflicts within a batch only (not with target). Instead of failing and bisecting when a conflict occurs, isolate the temporary conflict patches and proceed with remaining patches.