### PR TITLE
Gracefully handle when a push to `into_branch` results in a non-fast-forward error

### DIFF
--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -92,7 +92,7 @@ defmodule BorsNG.GitHub do
     sha
   end
 
-  @spec push(tconn, binary, binary) :: {:ok, binary} | {:error, term, term}
+  @spec push(tconn, binary, binary) :: {:ok, binary} | {:error, term, term, term}
   def push(repo_conn, sha, to) do
     GenServer.call(BorsNG.GitHub, {:push, repo_conn, {sha, to}}, Confex.fetch_env!(:bors, :api_github_timeout))
   end

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -499,24 +499,31 @@ defmodule BorsNG.Worker.Batcher do
 
   defp maybe_complete_batch(batch) do
     statuses = Repo.all(Status.all_for_batch(batch.id))
-    status = Batcher.State.summary_database_statuses(statuses)
+    initial_status = Batcher.State.summary_database_statuses(statuses)
     now = DateTime.to_unix(DateTime.utc_now(), :second)
-    if status != :running do
+    next_status = if initial_status != :running do
+      # need to change status (could go from :ok to :error if non-ff push)
+      maybe_completed_status = complete_batch(initial_status, batch, statuses)
+
+      # status can change so send_status should come after complete_batch
       batch.project
       |> get_repo_conn()
-      |> send_status(batch, status)
+      |> send_status(batch, maybe_completed_status)
       Project.ping!(batch.project_id)
-      complete_batch(status, batch, statuses)
+
+      maybe_completed_status
+    else
+      initial_status
     end
     batch
-    |> Batch.changeset(%{state: status, last_polled: now})
+    |> Batch.changeset(%{state: next_status, last_polled: now})
     |> Repo.update!()
-    if status != :running do
+    if next_status != :running do
       poll_(batch.project_id)
     end
   end
 
-  @spec complete_batch(Status.state, Batch.t, [Status.t]) :: :ok
+  @spec complete_batch(Status.state, Batch.t, [Status.t]) :: Status.state
   defp complete_batch(:ok, batch, statuses) do
     project = batch.project
     repo_conn = get_repo_conn(project)
@@ -525,24 +532,55 @@ defmodule BorsNG.Worker.Batcher do
       {:ok, x} -> {:ok, x}
     end
 
-    {:ok, _} = push_with_retry(
+    push_result = push_with_retry(
       repo_conn,
       batch.commit,
       batch.into_branch)
+
+    push_success = case push_result do
+      {:error, :push, 422, raw_error_content} ->
+        if String.contains?(raw_error_content, "Update is not a fast forward") do
+          false
+        else
+          {:ok, _} = push_result
+          true
+        end
+      _ ->
+        {:ok, _} = push_result
+        true
+    end
 
     patches = batch.id
     |> Patch.all_for_batch()
     |> Repo.all()
 
-    send_message(repo_conn, patches, {:succeeded, statuses})
+    case push_success do
+      true ->
+        send_message(repo_conn, patches, {:succeeded, statuses})
 
-    if toml.use_squash_merge do
-      Enum.each(patches, fn patch ->
-        send_message(repo_conn, [patch], {:merged, :squashed, batch.into_branch})
-        pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
-        pr = %BorsNG.GitHub.Pr{pr | state: :closed, title: "[Merged by Bors] - #{pr.title}"}
-        pr = GitHub.update_pr!(repo_conn, pr)
-      end)
+        if toml.use_squash_merge do
+          Enum.each(patches, fn patch ->
+            send_message(repo_conn, [patch], {:merged, :squashed, batch.into_branch})
+            pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
+            pr = %BorsNG.GitHub.Pr{pr | state: :closed, title: "[Merged by Bors] - #{pr.title}"}
+            pr = GitHub.update_pr!(repo_conn, pr)
+          end)
+        end
+
+        :ok
+
+      false ->
+        # retry the complete batch (no bisect required as build passed all statuses)
+        patch_links = batch.id
+        |> LinkPatchBatch.from_batch()
+        |> Repo.all()
+        reattempting_batch = Divider.clone_batch(patch_links, project.id, batch.into_branch)
+        poll_after_delay(project)
+
+        # send appropriate message to failed patches
+        send_message(repo_conn, patches, {:push_failed_non_ff, batch.into_branch})
+
+        :error
     end
   end
 
@@ -559,6 +597,8 @@ defmodule BorsNG.Worker.Batcher do
       poll_after_delay(project)
     end
     send_message(repo_conn, patches, {state, erred})
+
+    :error
   end
 
   # A delay has been observed between Bors sending the Status change

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -79,6 +79,9 @@ defmodule BorsNG.Worker.Batcher.Message do
   def generate_message({:canceled, :retrying}) do
     "This PR was included in a batch that was canceled, it will be automatically retried"
   end
+  def generate_message({:push_failed_non_ff, target_branch}) do
+    "This PR was included in a batch that successfully built, but then failed to merge into #{target_branch} (it was a non-fast-forward update). It will be automatically retried."
+  end
   def generate_message({state, statuses}) do
     is_new_year = get_is_new_year()
     msg = case state do


### PR DESCRIPTION
This PR introduces a fix for the issue reported in https://github.com/bors-ng/bors-ng/issues/856.

## Scenario
The `into_branch` changes, either from a manually merged PR or directly pushed to while a Bors batch is running.

## Previously
Bors would attempt to push to the `into_branch`, receive an error from the GitHub API, and then crash:

```
{{:badmatch,
  {:error, :push, 422,
   "{\"message\":\"Update is not a fast forward\",\"documentation_url\":\"https://developer.github.com/v3/git/refs/#update-a-reference\"}"}},
 [
   {BorsNG.Worker.Batcher, :complete_batch, 3,
    [file: 'lib/worker/batcher.ex', line: 518]},
   {BorsNG.Worker.Batcher, :maybe_complete_batch, 1,
    [file: 'lib/worker/batcher.ex', line: 499]},
   {BorsNG.Worker.Batcher, :handle_cast, 2,
    [file: 'lib/worker/batcher.ex', line: 84]},
   {:gen_server, :try_dispatch, 4,
    [file: 'gen_server.erl', line: 637]},
   {:gen_server, :handle_msg, 6,
    [file: 'gen_server.erl', line: 711]},
   {:proc_lib, :init_p_do_apply, 3,
    [file: 'proc_lib.erl', line: 249]}
 ]}
```

## New Behavior
The code checks to see if the push failed due to a non-fast-forward update error, and then retries the batch again (without a bisect). This seems safe and efficient to do, as the batch has already built successfully at this point.

These pictures demonstrate the new behavior. In this scenario, PR 107 and 108 were enqueued into bors and when the batch started to run, a third PR was directly merged:

<img width="437" alt="Screenshot showing the history that experienced an update to into_branch" src="https://user-images.githubusercontent.com/1007983/73217237-c8121100-4114-11ea-9524-137b769fdb76.png">

<img width="755" alt="The comment history for an affected PR in the batch" src="https://user-images.githubusercontent.com/1007983/73217248-ce07f200-4114-11ea-9ff4-c62c5d818ed7.png">


<Picture of comment history on PR>

## The changes
Some of the code changes were a result of changing the signature of `Batcher.complete_batch/3` to return new state. This was required to model the fact a Batch could take a new path and change to `:error` after being `:ok`.

The meaningful changes happen in `Batcher.complete_batch/3` where we match on the `push_success = false` case.

The behavior of `ServerMock` was also enhanced to exhibit specific kinds of failures for the `:push` message. 