### PR TITLE
Fix PR deserialization bug

### DIFF
--- a/lib/github/github/pr.ex
+++ b/lib/github/github/pr.ex
@@ -12,7 +12,7 @@ defmodule BorsNG.GitHub.Pr do
     base_ref: bitstring,
     head_sha: bitstring,
     user: BorsNG.GitHub.User.t,
-    mergeable: boolean | nil,
+    mergeable: boolean | nil, # not all PRs have this field populated
   }
   defstruct(
     number: 0,
@@ -95,6 +95,58 @@ defmodule BorsNG.GitHub.Pr do
       merged: (not is_nil merged_at),
       mergeable: mergeable
     }}
+  end
+  def from_json(%{
+    "number" => number,
+    "title" => title,
+    "body" => body,
+    "state" => state,
+    "base" => %{
+      "ref" => base_ref,
+      "repo" => %{
+        "id" => base_repo_id
+      }
+    },
+    "head" => %{
+      "sha" => head_sha,
+      "ref" => head_ref,
+      "repo" => %{
+        "id" => head_repo_id
+      }
+    },
+    "user" => %{
+      "id" => user_id,
+      "login" => user_login,
+      "avatar_url" => user_avatar_url,
+    },
+    "merged_at" => merged_at,
+  }) when is_integer(number) do
+    from_json %{
+      "number" => number,
+      "title" => title,
+      "body" => body,
+      "state" => state,
+      "base" => %{
+        "ref" => base_ref,
+        "repo" => %{
+          "id" => base_repo_id
+        }
+      },
+      "head" => %{
+        "sha" => head_sha,
+        "ref" => head_ref,
+        "repo" => %{
+          "id" => head_repo_id
+        }
+      },
+      "user" => %{
+        "id" => user_id,
+        "login" => user_login,
+        "avatar_url" => user_avatar_url,
+      },
+      "merged_at" => merged_at,
+      "mergeable" => nil,
+    }
   end
 
   def from_json(x) do

--- a/test/github_pr_test.exs
+++ b/test/github_pr_test.exs
@@ -1,0 +1,84 @@
+defmodule BorsNG.GitHub.GitHubPrTest do
+  use BorsNG.ConnCase
+
+  test "can parse a Poison-decoded JSON *without* mergeable field" do
+    result = BorsNG.GitHub.Pr.from_json %{
+      "number" => 1,
+      "title" => "T",
+      "body" => "B",
+      "state" => "open",
+      "base" => %{"ref" => "OTHER_BRANCH", "repo" => %{"id" => 456}},
+      "head" => %{
+        "sha" => "B",
+        "ref" => "BAR_BRANCH",
+        "repo" => %{
+          "id" => 345
+        },
+      },
+      "merged_at" => nil,
+      "user" => %{
+        "id" => 23,
+        "login" => "ghost",
+        "avatar_url" => "U"}}
+
+    assert result == {:ok, %BorsNG.GitHub.Pr{
+      number: 1,
+      title: "T",
+      body: "B",
+      state: :open,
+      base_ref: "OTHER_BRANCH",
+      head_sha: "B",
+      head_ref: "BAR_BRANCH",
+      head_repo_id: 345,
+      base_repo_id: 456,
+      user: %BorsNG.GitHub.User{
+        id: 23,
+        login: "ghost",
+        avatar_url: "U",
+      },
+      merged: false,
+      mergeable: nil
+    }}
+  end
+
+  test "can parse a Poison-decoded JSON *with* mergeable field" do
+    result = BorsNG.GitHub.Pr.from_json %{
+      "number" => 1,
+      "title" => "T",
+      "body" => "B",
+      "state" => "open",
+      "base" => %{"ref" => "OTHER_BRANCH", "repo" => %{"id" => 456}},
+      "head" => %{
+        "sha" => "B",
+        "ref" => "BAR_BRANCH",
+        "repo" => %{
+          "id" => 345
+        },
+      },
+      "merged_at" => nil,
+      "mergeable" => true,
+      "user" => %{
+        "id" => 23,
+        "login" => "ghost",
+        "avatar_url" => "U"}}
+
+    assert result == {:ok, %BorsNG.GitHub.Pr{
+      number: 1,
+      title: "T",
+      body: "B",
+      state: :open,
+      base_ref: "OTHER_BRANCH",
+      head_sha: "B",
+      head_ref: "BAR_BRANCH",
+      head_repo_id: 345,
+      base_repo_id: 456,
+      user: %BorsNG.GitHub.User{
+        id: 23,
+        login: "ghost",
+        avatar_url: "U",
+      },
+      merged: false,
+      mergeable: true
+    }}
+  end
+end

--- a/test/github_pr_test.exs
+++ b/test/github_pr_test.exs
@@ -1,8 +1,8 @@
 defmodule BorsNG.GitHub.GitHubPrTest do
   use BorsNG.ConnCase
 
-  test "can parse a Poison-decoded JSON *without* mergeable field" do
-    result = BorsNG.GitHub.Pr.from_json %{
+  setup do
+    pr_standard = %{
       "number" => 1,
       "title" => "T",
       "body" => "B",
@@ -20,6 +20,14 @@ defmodule BorsNG.GitHub.GitHubPrTest do
         "id" => 23,
         "login" => "ghost",
         "avatar_url" => "U"}}
+
+    {:ok, pr_standard: pr_standard}
+  end
+
+  test "can parse a Poison-decoded JSON *without* mergeable field", %{pr_standard: pr_standard} do
+    pr_without_field = pr_standard
+
+    result = BorsNG.GitHub.Pr.from_json pr_without_field
 
     assert result == {:ok, %BorsNG.GitHub.Pr{
       number: 1,
@@ -41,26 +49,10 @@ defmodule BorsNG.GitHub.GitHubPrTest do
     }}
   end
 
-  test "can parse a Poison-decoded JSON *with* mergeable field" do
-    result = BorsNG.GitHub.Pr.from_json %{
-      "number" => 1,
-      "title" => "T",
-      "body" => "B",
-      "state" => "open",
-      "base" => %{"ref" => "OTHER_BRANCH", "repo" => %{"id" => 456}},
-      "head" => %{
-        "sha" => "B",
-        "ref" => "BAR_BRANCH",
-        "repo" => %{
-          "id" => 345
-        },
-      },
-      "merged_at" => nil,
-      "mergeable" => true,
-      "user" => %{
-        "id" => 23,
-        "login" => "ghost",
-        "avatar_url" => "U"}}
+  test "can parse a Poison-decoded JSON *with* mergeable field", %{pr_standard: pr_standard} do
+    pr_with_field = Map.put(pr_standard, "mergeable", true)
+
+    result = BorsNG.GitHub.Pr.from_json pr_with_field
 
     assert result == {:ok, %BorsNG.GitHub.Pr{
       number: 1,


### PR DESCRIPTION
We noticed an issue where certain GitHub webhook requests to Bors returned `500` status codes and returned `Internal Server Error`:

![Screen Shot 2020-01-28 at 5 04 14 PM](https://user-images.githubusercontent.com/1007983/73316509-50b1af80-41f0-11ea-8aef-c569f6218712.png)

We've identified the root cause for the errors was in the JSON parsers for the `BorsNG.GitHub.Pr` and how it handles a "sometimes present" field named `mergeable`. It turns out the `mergeable` field is only present on GitHub v3 REST API Pull Request responses and *some* webhook events (only the `PullRequestEvent` / `pull_request` event type). The existing logic required the field be present ALWAYS.

## The fix
When the field is missing from the json argument, we give it a `nil` value. We also added a simple unit test for the `BorsNG.GitHub.Pr` module.

## Misc
We think this PR also fixes https://github.com/bors-ng/bors-ng/issues/856