### PR TITLE
When retrying a merge-conflict branch, don't comment

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -867,10 +867,14 @@ defmodule BorsNG.Worker.Batcher do
 
   defp send_message(repo_conn, patches, message) do
     body = Batcher.Message.generate_message(message)
-    Enum.each(patches, &GitHub.post_comment!(
-      repo_conn,
-      &1.pr_xref,
-      body))
+    case body do
+      nil -> :ok
+      _ ->
+        Enum.each(patches, &GitHub.post_comment!(
+          repo_conn,
+          &1.pr_xref,
+          body))
+    end
   end
 
   defp send_status(

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -65,7 +65,7 @@ defmodule BorsNG.Worker.Batcher.Message do
     "# Merge conflict"
   end
   def generate_message({:conflict, :retrying}) do
-    "This PR was included in a batch with a merge conflict, it will be automatically retried"
+    nil
   end
   def generate_message({:timeout, :failed}) do
     "# Timed out"

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -43,12 +43,6 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     assert expected_message == actual_message
   end
 
-  test "generate conflict/retry message" do
-    expected_message = "This PR was included in a batch with a merge conflict, it will be automatically retried"
-    actual_message = Message.generate_message({:conflict, :retrying})
-    assert expected_message == actual_message
-  end
-
   test "generate canceled message" do
     expected_message = "# Canceled"
     actual_message = Message.generate_message({:canceled, :failed})


### PR DESCRIPTION
In practice, on busy repositories, it's way too chatty.

Fixes #880