### PR TITLE
Improvements to prerun_timeout stuff

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -129,7 +129,10 @@ defmodule BorsNG.Worker.Batcher do
                 send_message(repo_conn, [patch], {:preflight, :timeout})
               _ ->
                 send_message(repo_conn, [patch], {:preflight, :waiting})
-                prerun_poll({reviewer, patch})
+                Process.send_after(
+                  self(),
+                  {:prerun_poll, 0, @prerun_poll_period, {reviewer, patch}},
+                  0)
             end
           {:error, message} ->
             send_message(repo_conn, [patch], {:preflight, message})
@@ -189,27 +192,39 @@ defmodule BorsNG.Worker.Batcher do
     end
   end
 
-  def handle_info({:prerun_poll, timeout, args}, proj_id) do
+  def handle_info({:prerun_poll, elapsed, period, args}, proj_id) do
     {reviewer, patch} = args
+
     case Repo.get(Patch.all(:awaiting_review), patch.id) do
       nil ->
         Logger.info("Patch #{patch.id} already left prerun, exiting prerun poll loop")
+
       _ ->
         project = Repo.get(Project, patch.project_id)
         repo_conn = get_repo_conn(project)
         {:ok, toml} = Batcher.GetBorsToml.get(repo_conn, patch.commit)
+
         prerun_timeout_ms = toml.prerun_timeout_sec * 1000
+
         case patch_preflight(repo_conn, patch) do
           :ok ->
             run(reviewer, patch)
-          :waiting when timeout > prerun_timeout_ms ->
+
+          :waiting when elapsed > prerun_timeout_ms ->
             send_message(repo_conn, [patch], {:preflight, :timeout})
+
           :waiting ->
-            Process.send_after(self(), {:prerun_poll, Kernel.trunc(timeout * 1.5), args}, timeout)
+            elapsed = elapsed + period
+            Process.send_after(
+              self(),
+              {:prerun_poll, elapsed, Kernel.trunc(period * 1.5), args},
+              period)
+
           {:error, message} ->
             send_message(repo_conn, [patch], {:preflight, message})
         end
     end
+
     {:noreply, proj_id}
   end
 
@@ -229,10 +244,6 @@ defmodule BorsNG.Worker.Batcher do
     else
       :again
     end
-  end
-
-  defp prerun_poll(args) do
-    Process.send_after(self(), {:prerun_poll, @prerun_poll_period, args}, 0)
   end
 
   defp run(reviewer, patch) do

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -39,7 +39,7 @@ defmodule BorsNG.Worker.Batcher do
 
   # Every half-hour
   @poll_period 30 * 60 * 1000
-  @prerun_poll_period 1000
+  @prerun_poll_period 5 * 60 * 1000
 
   # Public API
 
@@ -129,10 +129,7 @@ defmodule BorsNG.Worker.Batcher do
                 send_message(repo_conn, [patch], {:preflight, :timeout})
               _ ->
                 send_message(repo_conn, [patch], {:preflight, :waiting})
-                Process.send_after(
-                  self(),
-                  {:prerun_poll, 0, @prerun_poll_period, {reviewer, patch}},
-                  0)
+                Process.send_after(self(), {:prerun_poll, 0, {reviewer, patch}}, 0)
             end
           {:error, message} ->
             send_message(repo_conn, [patch], {:preflight, message})
@@ -192,7 +189,7 @@ defmodule BorsNG.Worker.Batcher do
     end
   end
 
-  def handle_info({:prerun_poll, elapsed, period, args}, proj_id) do
+  def handle_info({:prerun_poll, try_num, args}, proj_id) do
     {reviewer, patch} = args
 
     case Repo.get(Patch.all(:awaiting_review), patch.id) do
@@ -205,6 +202,7 @@ defmodule BorsNG.Worker.Batcher do
         {:ok, toml} = Batcher.GetBorsToml.get(repo_conn, patch.commit)
 
         prerun_timeout_ms = toml.prerun_timeout_sec * 1000
+        elapsed = try_num * @prerun_poll_period
 
         case patch_preflight(repo_conn, patch) do
           :ok ->
@@ -214,11 +212,7 @@ defmodule BorsNG.Worker.Batcher do
             send_message(repo_conn, [patch], {:preflight, :timeout})
 
           :waiting ->
-            elapsed = elapsed + period
-            Process.send_after(
-              self(),
-              {:prerun_poll, elapsed, Kernel.trunc(period * 1.5), args},
-              period)
+            Process.send_after(self(), {:prerun_poll, try_num + 1, args}, @prerun_poll_period)
 
           {:error, message} ->
             send_message(repo_conn, [patch], {:preflight, message})

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -115,22 +115,22 @@ defmodule BorsNG.Worker.Batcher do
       patch ->
         # Patch exists and is awaiting review
         # This will cause the PR to run after the patch's scheduled delay
-	# if all other conditions are met. It will poll if all conditions
-	# except CI are met and those CI are :waiting.
+        # if all other conditions are met. It will poll if all conditions
+        # except CI are met and those CI are :waiting.
         project = Repo.get!(Project, patch.project_id)
         repo_conn = get_repo_conn(project)
         case patch_preflight(repo_conn, patch) do
           :ok ->
-	    run(reviewer, patch)
+            run(reviewer, patch)
           :waiting ->
-	    {:ok, toml} = Batcher.GetBorsToml.get(repo_conn, patch.commit)
-	    case toml.prerun_timeout_sec do
-	      0 ->
-		send_message(repo_conn, [patch], {:preflight, :timeout})
-	      _ ->
-		send_message(repo_conn, [patch], {:preflight, :waiting})
-		prerun_poll({reviewer, patch})
-	    end
+            {:ok, toml} = Batcher.GetBorsToml.get(repo_conn, patch.commit)
+            case toml.prerun_timeout_sec do
+              0 ->
+                send_message(repo_conn, [patch], {:preflight, :timeout})
+              _ ->
+                send_message(repo_conn, [patch], {:preflight, :waiting})
+                prerun_poll({reviewer, patch})
+            end
           {:error, message} ->
             send_message(repo_conn, [patch], {:preflight, message})
         end

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -17,7 +17,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
     timeout_sec: (60 * 60),
     # prerun_timeout_sec controls how long bors will wait for all GitHub status checks to be completed before taking action.
     # If this value is set to 0, bors will not wait for status checks to be completed. Otherwise, Bors will poll status checks
-    # with exponential backoff. If prerun_timeout_sec or more ellapsed in the latest poll, Bors will return an error message.
+    # every 5 minutes. If prerun_timeout_sec or more elapsed in the latest poll, Bors will return an error message.
     # Half an hour by default.
     prerun_timeout_sec: (30 * 60),
     use_squash_merge: false,

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -750,8 +750,8 @@ defmodule BorsNG.Worker.BatcherTest do
       }}
     path = [{{:installation, 91}, 14}, :statuses, "Z"]
     GitHub.ServerMock.put_state(update_in(GitHub.ServerMock.get_state,
-	  path,
-	  &(Map.put(&1, "cn", :ok))))
+      path,
+      &(Map.put(&1, "cn", :ok))))
     Batcher.handle_info({:prerun_poll, 1000, {"rvr", patch}}, proj.id)
     state = GitHub.ServerMock.get_state()
     assert state == %{

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -122,6 +122,10 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     assert "aa" == Message.cut_body("aabcbd", "b")
   end
 
+  test "cut whole body" do
+    assert "" == Message.cut_body("abc", "")
+  end
+
   test "cut body with no match" do
     assert "ac" == Message.cut_body("ac", "b")
   end


### PR DESCRIPTION
Fixed the bug where bors is using the prerun_timout_sec not as the total time elapsed.

Also, removed the exponential backoff, since it get very big very soon. Changed the polling to a constant 5 mins.