### PR TITLE
Enhancement debian package manager tweaks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,13 @@ FROM elixir:${ELIXIR_VERSION} as builder
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-RUN apt-get update -q && apt-get install -y build-essential libtool autoconf curl git
+RUN apt-get update -q && apt-get --no-install-recommends install -y apt-utils ca-certificates build-essential libtool autoconf curl git
 
 RUN DEBIAN_CODENAME=$(sed -n 's/VERSION=.*(\(.*\)).*/\1/p' /etc/os-release) && \
     curl -q https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
     echo "deb http://deb.nodesource.com/node_8.x $DEBIAN_CODENAME main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update -q && \
-    apt-get install -y nodejs
+    apt-get --no-install-recommends install -y nodejs
 
 RUN mix local.hex --force && \
     mix local.rebar --force && \
@@ -41,7 +41,7 @@ RUN if [ -d .git ]; then \
 ####
 
 FROM debian:stretch-slim
-RUN apt-get update -q && apt-get install -y git-core libssl1.1 curl ca-certificates
+RUN apt-get update -q && apt-get --no-install-recommends install -y git-core libssl1.1 curl apt-utils ca-certificates
 
 ENV DOCKERIZE_VERSION=v0.6.0
 RUN curl -Ls https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz | \


### PR DESCRIPTION
Major Changes No 1 : debian package manager tweaks

By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Major Changes No 2 : added packages apt-utils ca-certificates

Because build is 

1.  Slow and in log it is showing because "apt-utils" not installed 

2. to avoid build to exits with error without having certificate