### PR TITLE
Retry status reports with a delay

### DIFF
--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -224,10 +224,20 @@ defmodule BorsNG.GitHub do
 
   @spec post_commit_status!(tconn, {binary, tstatus, binary, binary}) :: :ok
   def post_commit_status!(repo_conn, {sha, status, msg, url}) do
-    :ok = GenServer.call(
+    # Auto-retry
+    first_try = GenServer.call(
       BorsNG.GitHub,
       {:post_commit_status, repo_conn, {sha, status, msg, url}},
       Confex.fetch_env!(:bors, :api_github_timeout))
+    case first_try do
+      :ok -> :ok
+      msg =>
+        Process.sleep(1_000)
+        :ok = GenServer.call(
+          BorsNG.GitHub,
+          {:post_commit_status, repo_conn, {sha, status, msg, url}},
+          Confex.fetch_env!(:bors, :api_github_timeout))
+    end
     :ok
   end
 

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -231,7 +231,7 @@ defmodule BorsNG.GitHub do
       Confex.fetch_env!(:bors, :api_github_timeout))
     case first_try do
       :ok -> :ok
-      msg =>
+      msg ->
         Process.sleep(1_000)
         :ok = GenServer.call(
           BorsNG.GitHub,

--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -231,7 +231,7 @@ defmodule BorsNG.GitHub do
       Confex.fetch_env!(:bors, :api_github_timeout))
     case first_try do
       :ok -> :ok
-      msg ->
+      _ ->
         Process.sleep(1_000)
         :ok = GenServer.call(
           BorsNG.GitHub,


### PR DESCRIPTION
It's not great, and it really isn't a solution, but assuming I'm right and it's being caused by rate-limiting,
or by an intermittent Joken bug, or GitHub failing to maintain a consistent token database, it should help.

Part of #912