### PR TITLE
Use supported endpoint for generating installation token

### DIFF
--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -649,7 +649,7 @@ defmodule BorsNG.GitHub.Server do
     jwt_token = get_jwt_token()
     %{body: raw, status: 201} = "Bearer #{jwt_token}"
     |> tesla_client(@installation_content_type)
-    |> Tesla.post!("installations/#{installation_xref}/access_tokens?members=read", "")
+    |> Tesla.post!("app/installations/#{installation_xref}/access_tokens", "")
     Poison.decode!(raw)["token"]
   end
 


### PR DESCRIPTION
👋 Hey there!

I noticed the endpoint being used for generating tokens was [deprecated](https://developer.github.com/changes/2018-08-16-renaming-and-deprecation-of-github-app-installation-access-token-route/) a while ago and is slated to be removed eventually.

This PR updates the path to the supported version which is functionally equivalent and should send the same response.

I also removed the `"members=read"` param, I couldn't find any documentation on it and I don't think it's supported.

I didn't find any tests that needed updating, but please let me know if I missed any, I'm happy to fix any I've broken!

✨ 