### PR TITLE
Add Co-authored-by to squash commits.

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -428,13 +428,16 @@ defmodule BorsNG.Worker.Batcher do
             # Then compress the merge commit into tree into a single commit
             # appent it to the previous commit
             # Because the merges are iterative the contain *only* the changes from the PR vs the previous PR(or head)
-            message_body = Batcher.Message.cut_body(pr.body, toml.cut_body_after)
+
+            commit_message = Batcher.Message.generate_squash_commit_message(
+              pr, commits, user_email, toml.cut_body_after)
+
             cpt = GitHub.create_commit!(
               repo_conn,
               %{
                 tree: merge_commit.tree,
                 parents: [prev_head],
-                commit_message: "#{pr.title} (##{pr.number})\n\n#{message_body}",
+                commit_message: commit_message,
                 committer: %{name: user.login, email: user_email}})
 
             Logger.info("Commit Sha #{inspect(cpt)}")

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -103,6 +103,16 @@ defmodule BorsNG.Worker.Batcher.Message do
     "#{acc}\n  * #{status_link}"
   end
 
+  def generate_squash_commit_message(pr, commits, user_email, cut_body_after) do
+    message_body = cut_body(pr.body, cut_body_after)
+    co_authors = commits
+    |> Enum.filter(&(&1.author_email != user_email))
+    |> Enum.map(&("Co-authored-by: #{&1.author_name} <#{&1.author_email}>"))
+    |> Enum.uniq
+    |> Enum.join("\n")
+    "#{pr.title} (##{pr.number})\n\n#{message_body}\n\n#{co_authors}\n"
+  end
+
   def generate_commit_message(patch_links, cut_body_after, co_authors) do
     commit_title = Enum.reduce(patch_links,
       "Merge", &"#{&2} \##{&1.patch.pr_xref}")

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -168,4 +168,42 @@ defmodule BorsNG.Worker.BatcherMessageTest do
       co_authors)
     assert expected_message == actual_message
   end
+
+  test "cut commit message bodies in squash commits" do
+    expected_message = """
+    Synchronize background and foreground processing (#1)
+
+    Fixes that annoying bug.
+
+    Co-authored-by: B <b@b>
+    """
+    title = "Synchronize background and foreground processing"
+    body = """
+    Fixes that annoying bug.
+
+    <!-- boilerplate follows -->
+
+    Thank you for contributing to my awesome OSS project!
+    To make sure your PR is accepted ASAP, make sure all of this
+    stuff is done:
+
+    - [ ] Run the linter
+    - [ ] Run any new or changed tests
+    - [ ] This PR fixes #___ (fill in if it exists)
+    - [ ] Make sure your commit messages make sense
+    """
+    user_email = "a@a"
+    pr = %{
+      number: 1,
+      title: title,
+      body: body}
+    commits = [
+      %{author_email: user_email, author_name: "A"},
+      %{author_email: "b@b", author_name: "B"},
+      %{author_email: user_email, author_name: "A"},
+      %{author_email: "b@b", author_name: "B"}]
+    actual_message = Message.generate_squash_commit_message(
+      pr, commits, user_email, "\n\n<!-- boilerplate follows -->")
+    assert expected_message == actual_message
+  end
 end


### PR DESCRIPTION
This PR adds the `Co-authored-by:` trailers to squash commits.  Non-squash commits already have these trailers since #392.