### PR TITLE
Use user's name instead of login name for squash commits.

### DIFF
--- a/lib/github/github/full_user.ex
+++ b/lib/github/github/full_user.ex
@@ -5,7 +5,7 @@ defmodule BorsNG.GitHub.FullUser do
   See https://developer.github.com/v3/users/#get-a-single-user
   """
 
-  defstruct id: 0, login: "", avatar_url: "", email: ""
+  defstruct id: 0, login: "", avatar_url: "", email: "", name: nil
 
   @type tjson :: map
 
@@ -14,6 +14,7 @@ defmodule BorsNG.GitHub.FullUser do
                login: bitstring,
                avatar_url: bitstring,
                email: bitstring,
+               name: bitstring,
              }
 
 
@@ -35,12 +36,14 @@ defmodule BorsNG.GitHub.FullUser do
     "login" => login,
     "avatar_url" => avatar_url,
     "email" => email,
+    "name" => name,
   }) when is_integer(id) do
     {:ok, %BorsNG.GitHub.FullUser{
       id: id,
       login: login,
       avatar_url: avatar_url,
       email: email,
+      name: name,
     }}
   end
 

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -435,7 +435,7 @@ defmodule BorsNG.Worker.Batcher do
                 tree: merge_commit.tree,
                 parents: [prev_head],
                 commit_message: "#{pr.title} (##{pr.number})\n\n#{message_body}",
-                committer: %{name: user.login, email: user_email}})
+                committer: %{name: user.name || user.login, email: user_email}})
 
             Logger.info("Commit Sha #{inspect(cpt)}")
               cpt


### PR DESCRIPTION
At the moment, squash commits are created using the github login as author (in my case `gebner <gebner@gebner.org>`).  This PR changes this to use the user's name instead, if available.  (That is, `Gabriel Ebner <gebner@gebner.org>`.)

Fixes #867.