### PR TITLE
Make comments a bit quieter.

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -586,15 +586,15 @@ defmodule BorsNG.Worker.Batcher do
 
     case push_success do
       true ->
-        send_message(repo_conn, patches, {:succeeded, statuses})
-
         if toml.use_squash_merge do
           Enum.each(patches, fn patch ->
-            send_message(repo_conn, [patch], {:merged, :squashed, batch.into_branch})
+            send_message(repo_conn, [patch], {:merged, :squashed, batch.into_branch, statuses})
             pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
             pr = %BorsNG.GitHub.Pr{pr | state: :closed, title: "[Merged by Bors] - #{pr.title}"}
             GitHub.update_pr!(repo_conn, pr)
           end)
+        else
+          send_message(repo_conn, patches, {:succeeded, statuses})
         end
 
         :ok

--- a/test/attemptor_test.exs
+++ b/test/attemptor_test.exs
@@ -288,7 +288,7 @@ defmodule BorsNG.Worker.AttemptorTest do
         commits: %{
           "ini" => %{commit_message: "[ci skip][skip ci][skip netlify]", parents: ["ini"]},
           "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
-        comments: %{1 => ["## try\n\n# Build succeeded\n  * ci"]},
+        comments: %{1 => ["## try\n\nBuild succeeded:\n  * ci"]},
         statuses: %{"iniN" => [{"ci", :ok}]},
         files: %{"trying.tmp" => %{"bors.toml" => ~s/status = [ "ci" ]/}}
       }}
@@ -457,7 +457,7 @@ defmodule BorsNG.Worker.AttemptorTest do
                commits: %{
                  "ini" => %{commit_message: "[ci skip][skip ci][skip netlify]", parents: ["ini"]},
                  "iniN" => %{commit_message: "Try #1:test", parents: ["ini", "N"]}},
-               comments: %{1 => ["## try\n\n# Build succeeded\n  * ci"]},
+               comments: %{1 => ["## try\n\nBuild succeeded:\n  * ci"]},
                statuses: %{"iniN" => [{"ci", :ok}]},
                files: %{"trying.tmp" => %{"bors.toml" => ~s/status = [ "c%" ]/}}
              }}

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -89,7 +89,7 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{},
         commits: %{},
         comments: %{
-          1 => ["# Canceled"],
+          1 => ["Canceled."],
           2 => []
           },
         statuses: %{"N" => %{"bors" => :error}},
@@ -127,7 +127,7 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{},
         commits: %{},
         comments: %{
-          1 => ["# Canceled"]
+          1 => ["Canceled."]
           },
         statuses: %{"N" => %{"bors" => :error}},
         files: %{}
@@ -178,7 +178,7 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{},
         commits: %{},
         comments: %{
-          1 => ["# Canceled"],
+          1 => ["Canceled."],
           2 => ["This PR was included in a batch that was canceled, it will be automatically retried"]},
         statuses: %{
           "N" => %{"bors" => :error},
@@ -1041,7 +1041,7 @@ defmodule BorsNG.Worker.BatcherTest do
           "ini" => %{
             commit_message: "[ci skip][skip ci][skip netlify]",
             parents: ["ini"]}},
-        comments: %{1 => ["# Configuration problem\nbors.toml: not found"]},
+        comments: %{1 => ["Configuration problem:\nbors.toml: not found"]},
         statuses: %{"N" => %{"bors" => :error}},
         files: %{}
       }}
@@ -1243,7 +1243,7 @@ defmodule BorsNG.Worker.BatcherTest do
             commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n" <>
               "\nCo-authored-by: a <e>\n",
             parents: ["ini", "N"]}},
-        comments: %{1 => ["# Build succeeded\n  * ci"]},
+        comments: %{1 => ["Build succeeded:\n  * ci"]},
         statuses: %{
           "iniN" => %{"bors" => :ok, "ci" => :ok},
           "N" => %{"bors" => :ok}},
@@ -1409,7 +1409,7 @@ defmodule BorsNG.Worker.BatcherTest do
                    commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n" <>
                                    "\nCo-authored-by: a <e>\n",
                    parents: ["ini", "N"]}},
-               comments: %{1 => ["# Build succeeded\n  * ci"]},
+               comments: %{1 => ["Build succeeded:\n  * ci"]},
                statuses: %{
                  "iniN" => %{"bors" => :ok, "ci" => :ok},
                  "N" => %{"bors" => :ok}},
@@ -1476,7 +1476,7 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{"master" => "ini", "staging" => ""},
         commits: %{
           "ini" => %{commit_message: "[ci skip][skip ci][skip netlify]", parents: ["ini"]}},
-        comments: %{1 => ["# Merge conflict"]},
+        comments: %{1 => ["Merge conflict."]},
         statuses: %{"N" => %{"bors" => :error}, "iniN" => %{}},
         pulls: %{
           1 => %Pr{
@@ -1774,7 +1774,7 @@ defmodule BorsNG.Worker.BatcherTest do
             commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n" <>
               "\nCo-authored-by: b <f>\n",
             parents: ["iniN", "O"]}},
-        comments: %{1 => ["# Build succeeded\n  * ci"], 2 => []},
+        comments: %{1 => ["Build succeeded:\n  * ci"], 2 => []},
         statuses: %{
           "iniN" => %{"bors" => :ok},
           "N" => %{"bors" => :ok},
@@ -1923,7 +1923,7 @@ defmodule BorsNG.Worker.BatcherTest do
             commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n" <>
               "\nCo-authored-by: b <f>\n",
             parents: ["ini", "O"]}},
-        comments: %{2 => ["# Build succeeded\n  * ci"], 1 => []},
+        comments: %{2 => ["Build succeeded:\n  * ci"], 1 => []},
         statuses: %{
           "iniN" => %{"bors" => :running},
           "iniO" => %{"bors" => :ok},
@@ -1960,7 +1960,7 @@ defmodule BorsNG.Worker.BatcherTest do
             commit_message: "Merge #1\n\n1:  r=rvr a=[unknown]\n\n\n" <>
               "\nCo-authored-by: a <e>\n",
             parents: ["iniO", "N"]}},
-        comments: %{2 => ["# Build succeeded\n  * ci"], 1 => []},
+        comments: %{2 => ["Build succeeded:\n  * ci"], 1 => []},
         statuses: %{
           "iniN" => %{"bors" => :running},
           "iniO" => %{"bors" => :ok},
@@ -1994,8 +1994,8 @@ defmodule BorsNG.Worker.BatcherTest do
               "\nCo-authored-by: a <e>\n",
             parents: ["iniO", "N"]}},
         comments: %{
-          2 => ["# Build succeeded\n  * ci"],
-          1 => ["# Build succeeded\n  * ci"]},
+          2 => ["Build succeeded:\n  * ci"],
+          1 => ["Build succeeded:\n  * ci"]},
         statuses: %{
           "iniN" => %{"bors" => :running},
           "iniON" => %{"bors" => :ok},
@@ -2102,8 +2102,8 @@ defmodule BorsNG.Worker.BatcherTest do
               "\nCo-authored-by: a <e>\nCo-authored-by: b <f>\n",
             parents: ["ini", "N", "O"]}},
         comments: %{
-          1 => ["# Build failed (retrying...)\n  * ci"],
-          2 => ["# Build failed (retrying...)\n  * ci"]},
+          1 => ["Build failed (retrying...):\n  * ci"],
+          2 => ["Build failed (retrying...):\n  * ci"]},
         statuses: %{
           "iniNO" => %{"bors" => :error},
           "N" => %{"bors" => :error},
@@ -2141,8 +2141,8 @@ defmodule BorsNG.Worker.BatcherTest do
               "\nCo-authored-by: a <e>\n",
             parents: ["ini", "N"]}},
         comments: %{
-          1 => ["# Build failed (retrying...)\n  * ci"],
-          2 => ["# Build failed (retrying...)\n  * ci"]},
+          1 => ["Build failed (retrying...):\n  * ci"],
+          2 => ["Build failed (retrying...):\n  * ci"]},
         statuses: %{
           "iniNO" => %{"bors" => :error},
           "N" => %{"bors" => :running},
@@ -2178,9 +2178,9 @@ defmodule BorsNG.Worker.BatcherTest do
             parents: ["ini", "N"]}},
         comments: %{
           1 => [
-            "# Build failed\n  * ci",
-            "# Build failed (retrying...)\n  * ci"],
-          2 => ["# Build failed (retrying...)\n  * ci"]},
+            "Build failed:\n  * ci",
+            "Build failed (retrying...):\n  * ci"],
+          2 => ["Build failed (retrying...):\n  * ci"]},
         statuses: %{
           "iniNO" => %{"bors" => :error},
           "iniN" => %{"bors" => :error},
@@ -2222,9 +2222,9 @@ defmodule BorsNG.Worker.BatcherTest do
             parents: ["ini", "O"]}},
         comments: %{
           1 => [
-            "# Build failed\n  * ci",
-            "# Build failed (retrying...)\n  * ci"],
-          2 => ["# Build failed (retrying...)\n  * ci"]},
+            "Build failed:\n  * ci",
+            "Build failed (retrying...):\n  * ci"],
+          2 => ["Build failed (retrying...):\n  * ci"]},
         statuses: %{
           "iniNO" => %{"bors" => :error},
           "iniN" => %{"bors" => :error},
@@ -2265,11 +2265,11 @@ defmodule BorsNG.Worker.BatcherTest do
             parents: ["ini", "O"]}},
         comments: %{
           1 => [
-            "# Build failed\n  * ci",
-            "# Build failed (retrying...)\n  * ci"],
+            "Build failed:\n  * ci",
+            "Build failed (retrying...):\n  * ci"],
           2 => [
-            "# Build failed\n  * ci",
-            "# Build failed (retrying...)\n  * ci"]},
+            "Build failed:\n  * ci",
+            "Build failed (retrying...):\n  * ci"]},
         statuses: %{
           "iniNO" => %{"bors" => :error},
           "iniN" => %{"bors" => :error},
@@ -2399,7 +2399,7 @@ defmodule BorsNG.Worker.BatcherTest do
             commit_message: "Merge #2\n\n2:  r=rvr a=[unknown]\n\n\n" <>
               "\nCo-authored-by: b <f>\n",
             parents: ["release", "O"]}},
-        comments: %{1 => ["# Build succeeded\n  * ci"], 2 => []},
+        comments: %{1 => ["Build succeeded:\n  * ci"], 2 => []},
         statuses: %{
           "iniN" => %{"bors" => :ok},
           "N" => %{"bors" => :ok},
@@ -2521,8 +2521,8 @@ defmodule BorsNG.Worker.BatcherTest do
               "\nCo-authored-by: c <g>\nCo-authored-by: d <h>\n",
             parents: ["ini", "N", "O"]}},
         comments: %{
-          1 => ["# Build succeeded\n  * ci"],
-          2 => ["# Build succeeded\n  * ci"]
+          1 => ["Build succeeded:\n  * ci"],
+          2 => ["Build succeeded:\n  * ci"]
         },
         statuses: %{
           "iniNO" => %{"bors" => :ok},
@@ -2713,7 +2713,7 @@ defmodule BorsNG.Worker.BatcherTest do
               "\nCo-authored-by: a <e>\n",
             parents: ["ini", "N"]}},
         comments: %{
-          1 => ["# Timed out", "This PR was included in a batch that timed out, it will be automatically retried"],
+          1 => ["Timed out.", "This PR was included in a batch that timed out, it will be automatically retried"],
           2 => ["This PR was included in a batch that timed out, it will be automatically retried"]},
         statuses: %{
           "iniNO" => %{"bors" => :error},
@@ -2755,7 +2755,7 @@ defmodule BorsNG.Worker.BatcherTest do
               "\nCo-authored-by: b <f>\n",
             parents: ["ini", "O"]}},
         comments: %{
-          1 => ["# Timed out", "This PR was included in a batch that timed out, it will be automatically retried"],
+          1 => ["Timed out.", "This PR was included in a batch that timed out, it will be automatically retried"],
           2 => ["This PR was included in a batch that timed out, it will be automatically retried"]},
         statuses: %{
           "iniNO" => %{"bors" => :error},
@@ -2799,8 +2799,8 @@ defmodule BorsNG.Worker.BatcherTest do
               "\nCo-authored-by: b <f>\n",
             parents: ["ini", "O"]}},
         comments: %{
-          1 => ["# Timed out", "This PR was included in a batch that timed out, it will be automatically retried"],
-          2 => ["# Timed out", "This PR was included in a batch that timed out, it will be automatically retried"]},
+          1 => ["Timed out.", "This PR was included in a batch that timed out, it will be automatically retried"],
+          2 => ["Timed out.", "This PR was included in a batch that timed out, it will be automatically retried"]},
         statuses: %{
           "iniNO" => %{"bors" => :error},
           "iniN" => %{"bors" => :error},

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -4,47 +4,47 @@ defmodule BorsNG.Worker.BatcherMessageTest do
   alias BorsNG.Worker.Batcher.Message
 
   test "generate configuration problem message" do
-    expected_message = "# Configuration problem\nExample problem"
+    expected_message = "Configuration problem:\nExample problem"
     actual_message = Message.generate_message({:config, "Example problem"})
     assert expected_message == actual_message
   end
 
   test "generate retry message" do
-    expected_message = "# Build failed (retrying...)\n  * stat"
+    expected_message = "Build failed (retrying...):\n  * stat"
     example_statuses = [%{url: nil, identifier: "stat"}]
     actual_message = Message.generate_message({:retrying, example_statuses})
     assert expected_message == actual_message
   end
 
   test "generate retry message w/ url" do
-    expected_message = "# Build failed (retrying...)\n  * [stat](x)"
+    expected_message = "Build failed (retrying...):\n  * [stat](x)"
     example_statuses = [%{url: "x", identifier: "stat"}]
     actual_message = Message.generate_message({:retrying, example_statuses})
     assert expected_message == actual_message
   end
 
   test "generate failure message" do
-    expected_message = "# Build failed\n  * stat"
+    expected_message = "Build failed:\n  * stat"
     example_statuses = [%{url: nil, identifier: "stat"}]
     actual_message = Message.generate_message({:failed, example_statuses})
     assert expected_message == actual_message
   end
 
   test "generate success message" do
-    expected_message = "# Build succeeded\n  * stat"
+    expected_message = "Build succeeded:\n  * stat"
     example_statuses = [%{url: nil, identifier: "stat"}]
     actual_message = Message.generate_message({:succeeded, example_statuses})
     assert expected_message == actual_message
   end
 
   test "generate conflict message" do
-    expected_message = "# Merge conflict"
+    expected_message = "Merge conflict."
     actual_message = Message.generate_message({:conflict, :failed})
     assert expected_message == actual_message
   end
 
   test "generate canceled message" do
-    expected_message = "# Canceled"
+    expected_message = "Canceled."
     actual_message = Message.generate_message({:canceled, :failed})
     assert expected_message == actual_message
   end
@@ -56,7 +56,7 @@ defmodule BorsNG.Worker.BatcherMessageTest do
   end
 
   test "generate timeout message" do
-    expected_message = "# Timed out"
+    expected_message = "Timed out."
     actual_message = Message.generate_message({:timeout, :failed})
     assert expected_message == actual_message
   end
@@ -68,8 +68,8 @@ defmodule BorsNG.Worker.BatcherMessageTest do
   end
 
   test "generate merged into master message" do
-    expected_message = "# Pull request successfully merged into master."
-    actual_message = Message.generate_message({:merged, :squashed, "master"})
+    expected_message = "Pull request successfully merged into master.\n\nBuild succeeded:"
+    actual_message = Message.generate_message({:merged, :squashed, "master", []})
     assert expected_message == actual_message
   end
 


### PR DESCRIPTION
Bors adds several kinds of status comments, noting that CI has succeeded or that a branch has been merged.  These comments are quite distracting due their huge font size (they use level 1 headings).  This PR tones down the formatting of these comments a bit (the message is still the same).

 - Do not use level 1 headings.
 - For squash commits, combine both comments into one.  (Hence one less email per PR in a squash merge.)

Compare gebner/mathlib#2 and gebner/mathlib#3 for an example of the difference this PR makes.