### PR TITLE
Rename working branch for squash merge

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -383,7 +383,7 @@ defmodule BorsNG.Worker.Batcher do
     |> case do
       {:ok, toml} ->
         parents = if toml.use_squash_merge do
-          stmp = "#{batch.project.staging_branch}.tmp2"
+          stmp = "#{batch.project.staging_branch}-squash-merge.tmp"
           GitHub.force_push!(repo_conn, base.commit, stmp)
 
           new_head = Enum.reduce(patch_links, base.commit, fn patch_link, prev_head ->


### PR DESCRIPTION
The working branch used to create the squash merge commit should not be
tested by the CI system.
https://bors.tech/documentation/getting-started/ states:

> Your CI system should build the “staging” and “trying” branches, but
   should not build the “staging.tmp” and “trying.tmp” branches.

Suffixing with `.tmp` facilitate exclude by pattern: `*.tmp`.