### PR TITLE
allow configuring public-facing port

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,6 +23,10 @@
     "PUBLIC_HOST": {
       "description": "Where this website will be running (probably <app name>.herokuapp.com)"
     },
+    "PUBLIC_PORT": {
+      "description": "HTTPS port number on PUBLIC_HOST",
+      "value": "443"
+    },
     "SECRET_KEY_BASE": {
       "description": "A secret key for verifying the integrity of cookies",
       "generator": "secret"

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -9,7 +9,11 @@ config :bors, BorsNG.Database.Repo,
 
 config :bors, BorsNG.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [host: {:system, "PUBLIC_HOST"}, scheme: "https", port: 443],
+  url: [
+    host: {:system, "PUBLIC_HOST"},
+    scheme: "https",
+    port: {:system, :integer, "PUBLIC_PORT", 443}
+  ],
   check_origin: false,
   cache_static_manifest: "priv/static/cache_manifest.json",
   server: true,


### PR DESCRIPTION
Use the environment variable PUBLIC_PORT to specify ports other
than 443 for the external address of the bors instance.