### PR TITLE
When a file pattern has @ghost as owner, means no owner

### DIFF
--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -73,16 +73,21 @@ defmodule BorsNG.CodeOwnerParser do
 
         # Remove any nil entries (indicating review not required)
         # Pick the last matching entry (entries further down in the file have higher priority
-        Enum.reduce(pats, nil, fn x, acc ->
+        pats
+        |> Enum.reduce([], fn x, acc ->
           if x != nil do
             x
           else
             acc
           end
         end)
+        # If the last matching entry is @ghost, ignore it (it's a null owner on GH)
+        |> Enum.filter(fn x ->
+          !String.equivalent?("@ghost", x)
+        end)
       end)
 
-    required_reviewers = Enum.filter(required_reviewers, fn x -> x != nil end)
+    required_reviewers = Enum.filter(required_reviewers, fn x -> Enum.count(x) > 0 end)
 
     Logger.debug("Required reviewers: #{inspect(required_reviewers)}")
 

--- a/test/parse_owners_test.exs
+++ b/test/parse_owners_test.exs
@@ -378,4 +378,31 @@ defmodule BorsNG.ParseTest do
     assert Enum.count(Enum.at(reviewers, 0)) == 1
     assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/catch-all"
   end
+
+  test "Test @ghost user means no ownership" do
+    IO.inspect(File.cwd())
+    {:ok, codeowner} = File.read("test/testdata/code_owners_9")
+
+    {:ok, owner_file} = BorsNG.CodeOwnerParser.parse_file(codeowner)
+
+    files = [
+      %BorsNG.GitHub.File{filename: "docs/dog"}
+    ]
+
+    reviewers = BorsNG.CodeOwnerParser.list_required_reviews(owner_file, files)
+
+    assert Enum.count(reviewers) == 1
+    assert Enum.count(Enum.at(reviewers, 0)) == 1
+    assert Enum.at(Enum.at(reviewers, 0), 0) == "@owners/cat"
+
+    files = [
+      %BorsNG.GitHub.File{
+        filename: "docs/cat"
+      }
+    ]
+
+    reviewers = BorsNG.CodeOwnerParser.list_required_reviews(owner_file, files)
+
+    assert Enum.count(reviewers) == 0
+  end
 end

--- a/test/testdata/code_owners_9
+++ b/test/testdata/code_owners_9
@@ -1,0 +1,3 @@
+/docs/ @owners/cat
+# This means that this particular path has no concrete codeowner
+/docs/cat @ghost


### PR DESCRIPTION
This allows paths inside a codeownered path to be reset to a non
code owner path

>GitHub will parse the CODEOWNERS file from top to bottom, and thus for all files except Markdown files, the code owner will be @a_real_developer, but for Markdown files it will be @ghost. The trick is that GitHub does not request reviews from users who are not collaborators nor organization members, so @ghost will never receive a review request, and this amounts to "no one".
https://github.community/t5/How-to-use-Git-and-GitHub/CODEOWNERS-file-with-a-NOT-file-type-condition/m-p/31013/highlight/true#M8523