### PR TITLE
Approvers should be people who approved a PR

### DIFF
--- a/lib/github/github/reviews.ex
+++ b/lib/github/github/reviews.ex
@@ -23,7 +23,7 @@ defmodule BorsNG.GitHub.Reviews do
     # Get the list of users who have approved this PR
     approved_by =
       reviews
-      |> Enum.reject(fn {_, state} -> state == "DISMISSED" end)
+      |> Enum.filter(fn {_, state} -> state == "APPROVED" end)
       |> Enum.map(fn {username, _} -> username end)
 
     # Remove reviews that don't count

--- a/test/github_reviews_test.exs
+++ b/test/github_reviews_test.exs
@@ -65,7 +65,7 @@ defmodule BorsNG.GitHub.GitHubReviewsTest do
         }
       ])
 
-    assert result == %{"APPROVED" => 0, "CHANGES_REQUESTED" => 1, "approvers" => ["bert"]}
+    assert result == %{"APPROVED" => 0, "CHANGES_REQUESTED" => 1, "approvers" => []}
   end
 
   test "counts the last item (change request)", _ do
@@ -81,7 +81,7 @@ defmodule BorsNG.GitHub.GitHubReviewsTest do
         }
       ])
 
-    assert result == %{"APPROVED" => 0, "CHANGES_REQUESTED" => 1, "approvers" => ["bert"]}
+    assert result == %{"APPROVED" => 0, "CHANGES_REQUESTED" => 1, "approvers" => []}
   end
 
   test "counts the last item (approval)", _ do
@@ -116,7 +116,7 @@ defmodule BorsNG.GitHub.GitHubReviewsTest do
     assert result == %{
              "APPROVED" => 1,
              "CHANGES_REQUESTED" => 1,
-             "approvers" => ["bert", "ernie"]
+             "approvers" => ["ernie"]
            }
   end
 end


### PR DESCRIPTION
Should fix #938. Looks like nothing else relied on previous
semantics of "approvers"