### PR TITLE
#905 Always return at most one batch

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -1067,6 +1067,7 @@ defmodule BorsNG.Worker.Batcher do
         Repo.get!(Patch, l.patch_id).is_single
       end)
     end)
+    |> Enum.take(1)
     |> case do
       [batch] -> {batch, false}
       _ -> get_new_batch(project_id, into_branch, priority, true)


### PR DESCRIPTION
after #839 (files) it _might_ have been possible for the query to retunr more than one row. This change effectively prevents that, by ensuring we always returning the first element.  In case no rows are returned by the query the call to `Enum.take` is safe, as `Enum.take([], 0)` simply returns an empty enumerable.

Fixes: #905