### PR TITLE
fixes failed webpack builds on heroku

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update -q && apt-get --no-install-recommends install -y apt-utils ca
 
 RUN DEBIAN_CODENAME=$(sed -n 's/VERSION=.*(\(.*\)).*/\1/p' /etc/os-release) && \
     curl -q https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo "deb http://deb.nodesource.com/node_8.x $DEBIAN_CODENAME main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb http://deb.nodesource.com/node_12.x $DEBIAN_CODENAME main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update -q && \
     apt-get --no-install-recommends install -y nodejs
 

--- a/phoenix_static_buildpack.config
+++ b/phoenix_static_buildpack.config
@@ -1,7 +1,7 @@
 clean_cache=false
 compile="compile"
 config_vars_to_export=(ALLOW_PRIVATE_REPOS SCOUT_KEY SCOUT_LOG_LEVEL SCOUT_MONITOR)
-node_version=8.12.0
+node_version=12.17.0
 phoenix_relative_path=.
 phoenix_ex=phx
 assets_path=assets


### PR DESCRIPTION
When setting up a new heroku app the build step would fail during webpack complation, due to a dependency not supporting node 8. This is related to #968 which was for docker, but is the same root cause as the failure on heroku. Upgrading the configured version of node in the static buildpack seems to work fine.