### PR TITLE
Upgrade to latest master

### DIFF
--- a/lib/database/project.ex
+++ b/lib/database/project.ex
@@ -39,8 +39,8 @@ defmodule BorsNG.Database.Project do
       on_replace: :delete
     )
 
-    field(:staging_branch, :string, default: "staging")
-    field(:trying_branch, :string, default: "trying")
+    field :staging_branch, :string, default: "merge-staging"
+    field :trying_branch, :string, default: "merge-trying"
     field(:batch_poll_period_sec, :integer, default: 60 * 30)
     field(:batch_delay_sec, :integer, default: 10)
     field(:batch_timeout_sec, :integer, default: 60 * 60 * 2)

--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -151,6 +151,9 @@ defmodule BorsNG.Command do
   def parse_cmd("merge p=" <> rest), do: parse_priority(rest) ++ [:activate]
   def parse_cmd("merge=" <> arguments), do: parse_activation_args(arguments)
   def parse_cmd("merge" <> _), do: [:activate]
+  def parse_cmd("borsch!" <> _), do: [:activate]
+  def parse_cmd("bors bors" <> _), do: [:activate]
+  def parse_cmd(", would you be so kind to please merge this awesomeness" <> _), do: [:activate]
   def parse_cmd("delegate+" <> _), do: [:delegate]
   def parse_cmd("delegate=" <> arguments), do: parse_delegation_args(arguments)
   def parse_cmd("d+" <> _), do: [:delegate]


### PR DESCRIPTION
I reset to latest upstream master: https://github.com/bors-ng/bors-ng/commit/c04c58d9d05e874abaf679fd5d9087742a12b444. Then I merged our existing master to keep our changes.

It looks like 3f6c7cb was also merged upstream in bors-ng/bors-ng#862, so that is no longer needed.

There's no release notes, but here's the diff: https://github.com/bors-ng/bors-ng/compare/ef1cc41227a5e404928fdd7e71e260eae1312f43...c04c58d

Highlights include:

- bors-ng/bors-ng#919 should fix the Github deprecated API issue
- bors-ng/bors-ng#888 requires SSL, but we are already using it
- bors-ng/bors-ng#928 adds `Co-Authored By` to the squash commit message
- bors-ng/bors-ng#929 improves author naming