### PR TITLE
The required_approvals option should require up-to-date approvals

### DIFF
--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -263,6 +263,18 @@ defmodule BorsNG.GitHub do
     labels
   end
 
+  @spec get_commit_reviews!(tconn, integer | bitstring, binary) :: map
+  def get_commit_reviews!(repo_conn, issue_xref, sha) do
+    {:ok, labels} =
+      GenServer.call(
+        BorsNG.GitHub,
+        {:get_reviews, repo_conn, {issue_xref, sha}},
+        Confex.fetch_env!(:bors, :api_github_timeout)
+      )
+
+    labels
+  end
+
   @spec get_file!(tconn, binary, binary) :: binary | nil
   def get_file!(repo_conn, branch, path) do
     {:ok, file} =

--- a/lib/github/github/reviews.ex
+++ b/lib/github/github/reviews.ex
@@ -46,4 +46,15 @@ defmodule BorsNG.GitHub.Reviews do
     )
     |> Map.put("approvers", approved_by)
   end
+
+  @spec filter_sha!([map], nil) :: [map]
+  def filter_sha!(json, nil) do
+    json
+  end
+
+  @spec filter_sha!([map], binary) :: [map]
+  def filter_sha!(json, sha) do
+    json
+    |> Enum.filter(fn %{"commit_id" => commit_id} -> commit_id == sha end)
+  end
 end

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -424,13 +424,18 @@ defmodule BorsNG.GitHub.Server do
     end
   end
 
-  def do_handle_call(:get_reviews, {{:raw, token}, repo_xref}, {issue_xref}) do
+  def do_handle_call(:get_reviews, {{:raw, token}, repo_xref}, {issue_xref, sha}) do
     reviews =
       token
       |> get_reviews_json_!("#{site()}/repositories/#{repo_xref}/pulls/#{issue_xref}/reviews", [])
+      |> GitHub.Reviews.filter_sha!(sha)
       |> GitHub.Reviews.from_json!()
 
     {:ok, reviews}
+  end
+
+  def do_handle_call(:get_reviews, repo_conn, {issue_xref}, state) do
+    do_handle_call(:get_reviews, repo_conn, {issue_xref, nil}, state)
   end
 
   def do_handle_call(:get_file, repo_conn, {branch, path}) do

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -434,8 +434,8 @@ defmodule BorsNG.GitHub.Server do
     {:ok, reviews}
   end
 
-  def do_handle_call(:get_reviews, repo_conn, {issue_xref}, state) do
-    do_handle_call(:get_reviews, repo_conn, {issue_xref, nil}, state)
+  def do_handle_call(:get_reviews, repo_conn, {issue_xref}) do
+    do_handle_call(:get_reviews, repo_conn, {issue_xref, nil})
   end
 
   def do_handle_call(:get_file, repo_conn, {branch, path}) do

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -957,7 +957,9 @@ defmodule BorsNG.Worker.Batcher do
     Logger.info(
       "Code review status: Label Check #{passed_label} Passed Status: #{
         no_error_status and no_waiting_status
-      } Passed Review: #{passed_review} CODEOWNERS: #{code_owners_approved}"
+      } Passed Review: #{passed_review} CODEOWNERS: #{code_owners_approved} Passed Up-To-Date Review: #{
+        passed_up_to_date_review
+      }"
     )
 
     case {passed_label, no_error_status, no_waiting_status, passed_review, code_owners_approved,

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -90,18 +90,6 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
               }
           end
 
-        # required_approvals = Map.get(toml, "required_approvals", nil)
-        # up_to_date_approvals =
-        #   case required_approvals do
-        #     required_approvals when required_approvals > 0 ->
-        #       # if approvals are required, we require them to be up to date by default
-        #       Map.get(toml, "up_to_date_approvals", true)
-
-        #     _ ->
-        #       false
-        #   end
-
-
         toml = %BorsNG.Worker.Batcher.BorsToml{
           status: Map.get(toml, "status", []),
           use_squash_merge:
@@ -115,7 +103,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           timeout_sec: Map.get(toml, "timeout_sec", 60 * 60),
           prerun_timeout_sec: Map.get(toml, "prerun_timeout_sec", 30 * 60),
           required_approvals: Map.get(toml, "required_approvals", nil),
-          up_to_date_approvals:  Map.get(toml, "up_to_date_approvals", false),
+          up_to_date_approvals: Map.get(toml, "up_to_date_approvals", false),
           cut_body_after: Map.get(toml, "cut_body_after", nil),
           delete_merged_branches:
             Map.get(

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -24,6 +24,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             prerun_timeout_sec: 30 * 60,
             use_squash_merge: false,
             required_approvals: nil,
+            up_to_date_approvals: false,
             cut_body_after: nil,
             delete_merged_branches: false,
             use_codeowners: false,
@@ -42,6 +43,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           timeout_sec: integer,
           prerun_timeout_sec: integer,
           required_approvals: integer | nil,
+          up_to_date_approvals: boolean,
           cut_body_after: binary | nil,
           delete_merged_branches: boolean,
           use_codeowners: boolean,
@@ -88,6 +90,18 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
               }
           end
 
+        # required_approvals = Map.get(toml, "required_approvals", nil)
+        # up_to_date_approvals =
+        #   case required_approvals do
+        #     required_approvals when required_approvals > 0 ->
+        #       # if approvals are required, we require them to be up to date by default
+        #       Map.get(toml, "up_to_date_approvals", true)
+
+        #     _ ->
+        #       false
+        #   end
+
+
         toml = %BorsNG.Worker.Batcher.BorsToml{
           status: Map.get(toml, "status", []),
           use_squash_merge:
@@ -101,6 +115,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           timeout_sec: Map.get(toml, "timeout_sec", 60 * 60),
           prerun_timeout_sec: Map.get(toml, "prerun_timeout_sec", 30 * 60),
           required_approvals: Map.get(toml, "required_approvals", nil),
+          up_to_date_approvals:  Map.get(toml, "up_to_date_approvals", false),
           cut_body_after: Map.get(toml, "cut_body_after", nil),
           delete_merged_branches:
             Map.get(

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -59,6 +59,10 @@ defmodule BorsNG.Worker.Batcher.Message do
     ":-1: Rejected by too few approved reviews"
   end
 
+  def generate_message({:preflight, :insufficient_up_to_date_approvals}) do
+    ":-1: Rejected by too few up-to-date approved reviews (some of the PR reviews are stale)"
+  end
+
   def generate_message({:preflight, :missing_code_owner_approval}) do
     ":-1: Rejected because of missing code owner approval"
   end

--- a/test/batcher/bors_toml_test.exs
+++ b/test/batcher/bors_toml_test.exs
@@ -91,4 +91,9 @@ defmodule BatcherBorsTomlTest do
     r = BorsToml.new(~s/status = ["exl"]\n[committer]\nemail = "bors@ex.com"/)
     assert r == {:error, :committer_details}
   end
+
+  test "up_to_date_approvals can be set to true " do
+    {:ok, toml} = BorsToml.new(~s/status = ["exl"]\nup_to_date_approvals = true/)
+    assert toml.up_to_date_approvals == true
+  end
 end

--- a/test/github_reviews_test.exs
+++ b/test/github_reviews_test.exs
@@ -119,4 +119,73 @@ defmodule BorsNG.GitHub.GitHubReviewsTest do
              "approvers" => ["ernie"]
            }
   end
+
+  test "dont filter anything on nil", _ do
+    result =
+      BorsNG.GitHub.Reviews.filter_sha!(
+        [
+          %{
+            "user" => %{"login" => "bert"},
+            "state" => "CHANGES_REQUESTED",
+            "commit_id" => "123"
+          },
+          %{
+            "user" => %{"login" => "ernie"},
+            "state" => "APPROVED",
+            "commit_id" => "456"
+          }
+        ],
+        nil
+      )
+
+    assert result == [
+             %{
+               "user" => %{"login" => "bert"},
+               "state" => "CHANGES_REQUESTED",
+               "commit_id" => "123"
+             },
+             %{
+               "user" => %{"login" => "ernie"},
+               "state" => "APPROVED",
+               "commit_id" => "456"
+             }
+           ]
+  end
+
+  test "filter by commit id", _ do
+    result =
+      BorsNG.GitHub.Reviews.filter_sha!(
+        [
+          %{
+            "user" => %{"login" => "bert"},
+            "state" => "CHANGES_REQUESTED",
+            "commit_id" => "123"
+          },
+          %{
+            "user" => %{"login" => "ernie"},
+            "state" => "APPROVED",
+            "commit_id" => "456"
+          },
+          %{
+            "user" => %{"login" => "eric"},
+            "state" => "CHANGES_REQUESTED",
+            "commit_id" => "456"
+          }
+        ],
+        "456"
+      )
+
+    assert result == [
+             %{
+               "user" => %{"login" => "ernie"},
+               "state" => "APPROVED",
+               "commit_id" => "456"
+             },
+             %{
+               "user" => %{"login" => "eric"},
+               "state" => "CHANGES_REQUESTED",
+               "commit_id" => "456"
+             }
+           ]
+  end
 end


### PR DESCRIPTION
### Overview
This is an attempt at implementing: https://forum.bors.tech/t/the-required-approvals-option-should-require-up-to-date-approvals/471

The implementation follows the RFC: a flag called `up_to_date_approvals` is added to `bors.toml`, which defaults to `false`. When this flag is set to `true` we validate that the reviews are associated with the current commit id that BORS is running on for the patch (and not just associated with the pr in general).

We still do the regular check for any PR reviews for two reasons:
1. We want to identify rejecting reviews, even if they are not associated with the last commit
2. We want to differentiate the error message of the case where a pr doesn't have enough reviewers and the case where the reviews are not up to date (since getting the original error message when you do have enough reviewers can be quite confusing, as Github's  association between a review and a commit isn't very clear from the UI)

### Current caveats of the implementation:
1. Unlike GitHub's behavior, when a user adds a merge commit that doesn't change the code to the repository, BORS will now require re-approves (where GitHub identifies this and don't mark the reviews as stale). The reason this is not implemented is that it would require a potentially large amount of API calls to GitHub (to fetch each commit's number of files changed) and since when using the BORS workflow you don't have to do merge commits, this seems fine. Would love to hear some input on how we can implement this in a way that is more cost-effective.
2. The status messages aren't as verbose as the RFC suggested (x out of Y are stale). The reason is that it will require much more code changes, given the current structure of the `GitHub` and `reviews` files. This again felt like it wasn't cost-effective enough.
3. Currently does not require up-to-date review from code owners (i.e. if 1 reviewer is required + code owner reviews are required, a PR will be accepted in the case where the code owner review is not up to date, but an additional up-to-date review exists which is not by a code owner). I am not sure if that is aligned with GitHub's behavior, but I think we can open a separate issue to incorporate this to code owner reviews if we choose to.

### Things to note:
1. The flag is currently off by default (same as GitHub's behavior for dismissing stale PRs) but this should probably be discussed.
2. Opening this early to get some guidance on what steps on the way I missed (opening an issue, some more RFC related stuff) and to let people know I am actively working on it. Also since this is my first time opening a PR for BORS, I am assuming that I overlooked some things so please be as scrutinous as possible :) 

### Open tasks:
Opened this ASAP to mark that I am working on it and prevent duplicate work & get fast feedback. Here is a list of things left to be done (should be updated over time).
- [x] test on a BORS instance (not just UT)
