### PR TITLE
Add autocorrect rule for `bors +`

### DIFF
--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -157,6 +157,8 @@ defmodule BorsNG.Command do
   def parse_cmd("d=" <> arguments), do: parse_delegation_args(arguments)
   def parse_cmd("+r" <> _), do: [{:autocorrect, "r+"}]
   def parse_cmd("-r" <> _), do: [{:autocorrect, "r-"}]
+  def parse_cmd("+"), do: [{:autocorrect, "r+"}]
+  def parse_cmd("-"), do: [{:autocorrect, "r-"}]
   def parse_cmd("ping" <> _), do: [:ping]
   def parse_cmd("p=" <> rest), do: parse_priority(rest)
   def parse_cmd("retry" <> _), do: [:retry]


### PR DESCRIPTION
This was added to account for a situation I saw at Cerebrum.