### PR TITLE
Log client requests to GitHub

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -26,7 +26,8 @@ config :bors,
   ecto_repos: [BorsNG.Database.Repo],
   api_github_root: {:system, :string, "GITHUB_URL_ROOT_API", "https://api.github.com"},
   html_github_root: {:system, :string, "GITHUB_URL_ROOT_HTML", "https://github.com"},
-  api_github_timeout: {:system, :integer, "GITHUB_API_TIMEOUT", 10_000}
+  api_github_timeout: {:system, :integer, "GITHUB_API_TIMEOUT", 10_000},
+  log_outgoing: {:system, "BORS_LOG_OUTGOING", false}
 
 # General application configuration
 config :bors, BorsNG,

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -891,7 +891,8 @@ defmodule BorsNG.GitHub.Server do
            {"accept", content_type},
            {"user-agent", "bors-ng https://bors.tech"}
          ]},
-        {Tesla.Middleware.Retry, delay: 100, max_retries: 5}
+        {Tesla.Middleware.Retry, delay: 100, max_retries: 5},
+        {Tesla.Middleware.Logger, filter_headers: ["authorization"]}
       ],
       {Tesla.Adapter.Httpc, [ssl: ssl_opts]}
     )


### PR DESCRIPTION
Hello,

I'm not sure this is something you want to do, but it helped me a lot for testing my changes in https://github.com/bors-ng/bors-ng/pull/995

Here is a sample of what is looks like:

```
2020-08-03T07:00:14.968410+00:00 heroku[router]: at=info method=POST path="/webhook/github" host=bors-tests.herokuapp.com request_id=73bdce15-00b7-4ce5-8a3f-a6c95a572b31 fwd="140.82.115.155" dyno=web.1 connect=1ms service=799ms status=200 bytes=259 protocol=https
2020-08-03T07:00:14.929880+00:00 app[web.1]: 07:00:14.929 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/pulls/9 -> 200 (455.305 ms)
2020-08-03T07:00:14.966583+00:00 app[web.1]: 07:00:14.966 request_id=73bdce15-00b7-4ce5-8a3f-a6c95a572b31 pid=<0.549.0> [info] Sent 200 in 797ms
2020-08-03T07:00:15.168988+00:00 app[web.1]: 07:00:15.168 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/contents/bors.toml -> 200 (194.823 ms)
2020-08-03T07:00:15.420605+00:00 app[web.1]: 07:00:15.420 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/issues/9/labels -> 200 (226.039 ms)
2020-08-03T07:00:15.621675+00:00 app[web.1]: 07:00:15.621 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/commits/5a99b398b8c1d16f1ba5120b6670fdb31903c38f/status -> 200 (200.326 ms)
2020-08-03T07:00:16.079808+00:00 app[web.1]: 07:00:16.079 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/commits/5a99b398b8c1d16f1ba5120b6670fdb31903c38f/check-runs -> 200 (457.674 ms)
2020-08-03T07:00:16.286852+00:00 app[web.1]: 07:00:16.286 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/commits/5a99b398b8c1d16f1ba5120b6670fdb31903c38f/status -> 200 (206.264 ms)
2020-08-03T07:00:16.468819+00:00 app[web.1]: 07:00:16.467 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/commits/5a99b398b8c1d16f1ba5120b6670fdb31903c38f/check-runs -> 200 (180.530 ms)
2020-08-03T07:00:16.468828+00:00 app[web.1]: 07:00:16.467 pid=<0.547.0> [info] Checking code owners
2020-08-03T07:00:16.667539+00:00 app[web.1]: 07:00:16.666 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/contents/.github/CODEOWNERS -> 200 (198.168 ms)
2020-08-03T07:00:16.687920+00:00 app[web.1]: 07:00:16.686 pid=<0.547.0> [info] CODEOWNERS file %BorsNG.CodeOwners{patterns: [%BorsNG.FilePattern{approvers: ["@organisationjetteauloin/dummy"], file_pattern: "*"}]}
2020-08-03T07:00:16.948517+00:00 app[web.1]: 07:00:16.944 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/pulls/9/files -> 200 (257.753 ms)
2020-08-03T07:00:16.948523+00:00 app[web.1]: 07:00:16.944 pid=<0.547.0> [info] Files found: [%BorsNG.GitHub.File{filename: "foo"}]
2020-08-03T07:00:17.218261+00:00 app[web.1]: 07:00:17.217 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/pulls/9/reviews -> 200 (272.747 ms)
2020-08-03T07:00:17.223652+00:00 app[web.1]: 07:00:17.223 pid=<0.547.0> [info] Passed reviews: %{"APPROVED" => 0, "CHANGES_REQUESTED" => 0, "approvers" => []}
2020-08-03T07:00:17.224455+00:00 app[web.1]: 07:00:17.223 pid=<0.547.0> [info] Approved: false
2020-08-03T07:00:17.224455+00:00 app[web.1]: 07:00:17.223 pid=<0.547.0> [info] Approved reviews: [false]
2020-08-03T07:00:17.224456+00:00 app[web.1]: 07:00:17.223 pid=<0.547.0> [info] Code Owner approval: false
2020-08-03T07:00:17.432279+00:00 app[web.1]: 07:00:17.431 pid=<0.344.0> [info] GET https://api.github.com/repositories/284424834/pulls/9/reviews -> 200 (207.211 ms)
2020-08-03T07:00:17.432281+00:00 app[web.1]: 07:00:17.431 pid=<0.547.0> [info] Code review status: Label Check true Passed Status: true Passed Review: sufficient CODEOWNERS: false Passed Up-To-Date Review: sufficient
2020-08-03T07:00:18.111947+00:00 app[web.1]: 07:00:18.111 pid=<0.344.0> [info] POST https://api.github.com/repositories/284424834/issues/9/comments -> 201 (679.347 ms)
```