### PR TITLE
Don't simply ignore unset commit statuses

### DIFF
--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -962,7 +962,7 @@ defmodule BorsNG.Worker.BatcherTest do
         branches: %{},
         commits: %{},
         comments: %{1 => []},
-        statuses: %{"Z" => %{"cn" => :ok}},
+        statuses: %{"Z" => %{"cn" => :ok, "arbitrary_uninterested_status" => :running}},
         files: %{"Z" => %{"bors.toml" => ~s/status = [ "ci" ]\npr_status = [ "cn", "cm" ]/}}
       }
     })
@@ -988,7 +988,7 @@ defmodule BorsNG.Worker.BatcherTest do
                    ":clock1: Waiting for PR status (Github check) to be set, probably by CI. Bors will automatically try to run when all required PR statuses are set."
                  ]
                },
-               statuses: %{"Z" => %{"cn" => :ok}},
+               statuses: %{"Z" => %{"cn" => :ok, "arbitrary_uninterested_status" => :running}},
                files: %{
                  "Z" => %{"bors.toml" => ~s/status = [ "ci" ]\npr_status = [ "cn", "cm" ]/}
                }
@@ -1018,7 +1018,7 @@ defmodule BorsNG.Worker.BatcherTest do
                    ":clock1: Waiting for PR status (Github check) to be set, probably by CI. Bors will automatically try to run when all required PR statuses are set."
                  ]
                },
-               statuses: %{"Z" => %{"cn" => :ok, "cm" => :error}},
+               statuses: %{"Z" => %{"cn" => :ok, "cm" => :error, "arbitrary_uninterested_status" => :running}},
                files: %{
                  "Z" => %{"bors.toml" => ~s/status = [ "ci" ]\npr_status = [ "cn", "cm" ]/}
                }


### PR DESCRIPTION
Fixes #1001.

Previously we treated unset statuses as :ok. This, I think, is
non-intuitive as it's entirely possible for CI to be slow to set even a
pending status. If someone `bors r+`s before that's done, bors would go
ahead and create the merge commit, which is not the contract defined by
the `pr_status` config (it's supposed to enumerate the list of commit statuses
that must pass on the PR commit when it is r+-ed).