### PR TITLE
Unique list of reviewers for multiple code changes #933

### DIFF
--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -87,7 +87,10 @@ defmodule BorsNG.CodeOwnerParser do
         end)
       end)
 
-    required_reviewers = Enum.filter(required_reviewers, fn x -> Enum.count(x) > 0 end)
+    required_reviewers =
+      required_reviewers
+      |> Enum.filter(fn x -> Enum.count(x) > 0 end)
+      |> Enum.uniq()
 
     Logger.debug("Required reviewers: #{inspect(required_reviewers)}")
 

--- a/test/parse_owners_test.exs
+++ b/test/parse_owners_test.exs
@@ -155,6 +155,31 @@ defmodule BorsNG.ParseTest do
     assert Enum.at(Enum.at(reviewers, 0), 1) == "@my_org/my_other_team"
   end
 
+  test "Extracts unique reviewers for multiple changes" do
+    IO.inspect(File.cwd())
+    {:ok, codeowner} = File.read("test/testdata/code_owners_7")
+
+    {:ok, owner_file} = BorsNG.CodeOwnerParser.parse_file(codeowner)
+
+    files = [
+      %BorsNG.GitHub.File{
+        filename: "src/dir1/test"
+      },
+      %BorsNG.GitHub.File{
+        filename: "src/dir2/test"
+      },
+      %BorsNG.GitHub.File{
+        filename: "src/dir3/test"
+      }
+    ]
+
+    reviewers = BorsNG.CodeOwnerParser.list_required_reviews(owner_file, files)
+
+    assert Enum.count(reviewers) == 1
+    assert Enum.count(Enum.at(reviewers, 0)) == 1
+    assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/test_team_2"
+  end
+
   test "Test Double Asterisk in the middle" do
     IO.inspect(File.cwd())
     {:ok, codeowner} = File.read("test/testdata/code_owners_7")


### PR DESCRIPTION
This is a simple attempt to fix https://github.com/bors-ng/bors-ng/issues/993

While checking the `parse_owners.ex` file, i realized that it returns one reviewer per changed file even when all changes belong to the same codeowners.

To be honest, I did not dig very deep and it could be that this happens somewhere later in the pipeline already and i just missed it.

If that's the wrong approach because approvals are indeed tracked per file, i am happy to give it another go, ideally with some directions