### PR TITLE
Change base before delete

### DIFF
--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -103,6 +103,18 @@ defmodule BorsNG.GitHub do
     prs
   end
 
+  @spec get_open_prs_with_base!(tconn, binary) :: [tpr]
+  def get_open_prs_with_base!(repo_conn, base) do
+    {:ok, prs} =
+      GenServer.call(
+        BorsNG.GitHub,
+        {:get_open_prs_with_base, repo_conn, {base}},
+        100_000
+      )
+
+    prs
+  end
+
   @spec push!(tconn, binary, binary) :: binary
   def push!(repo_conn, sha, to) do
     {:ok, sha} =

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -172,6 +172,15 @@ defmodule BorsNG.GitHub.Server do
      )}
   end
 
+  def do_handle_call(:get_open_prs_with_base, {{:raw, token}, repo_xref}, {base}) do
+    {:ok,
+     get_open_prs_!(
+       token,
+       "#{site()}/repositories/#{repo_xref}/pulls?state=open&base=#{base}",
+       []
+     )}
+  end
+
   def do_handle_call(:push, repo_conn, {sha, to}) do
     repo_conn
     |> patch!("git/refs/heads/#{to}", Poison.encode!(%{sha: sha}))

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -129,7 +129,8 @@ defmodule BorsNG.GitHub.Server do
       Poison.encode!(%{
         title: pr.title,
         body: pr.body,
-        state: pr.state
+        state: pr.state,
+        base: pr.base_ref
       })
     )
     |> case do

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -160,6 +160,20 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:update_pr, repo_conn, pr, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn),
+         {:ok, pulls} <- Map.fetch(repo, :pulls) do
+      pulls = %{pulls | pr.number => pr}
+      repo = %{repo | pulls: pulls}
+      state = %{state | repo_conn => repo}
+      {{:ok, pr}, state}
+    end
+    |> case do
+      {{:ok, _}, _} = res -> res
+      _ -> {{:error, :update_pr}, state}
+    end
+  end
+
   def do_handle_call(:get_pr_files, repo_conn, {_pr_xref}, state) do
     files =
       with {:ok, repo} <- Map.fetch(state, repo_conn),

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -210,6 +210,23 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:get_open_prs_with_base, repo_conn, {base}, state) do
+    with(
+      {:ok, repo} <- Map.fetch(state, repo_conn),
+      {:ok, pulls} <- Map.fetch(repo, :pulls),
+      do: {
+        :ok,
+        Map.values(pulls)
+        |> Enum.filter(&(&1.state == :open))
+        |> Enum.filter(&(&1.base_ref == base))
+      }
+    )
+    |> case do
+      {:ok, _} = res -> {res, state}
+      _ -> {{:error, :get_open_prs_with_base}, state}
+    end
+  end
+
   def do_handle_call(:push, repo_conn, {sha, to}, state) do
     with {:ok, repo} <- Map.fetch(state, repo_conn),
          {:ok, branches} <- Map.fetch(repo, :branches),

--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -28,7 +28,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             cut_body_after: nil,
             delete_merged_branches: false,
             use_codeowners: false,
-            committer: nil
+            committer: nil,
+            update_base_for_deletes: false
 
   @type tcommitter :: %{
           name: binary,
@@ -47,7 +48,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           cut_body_after: binary | nil,
           delete_merged_branches: boolean,
           use_codeowners: boolean,
-          committer: tcommitter
+          committer: tcommitter,
+          update_base_for_deletes: boolean
         }
 
   @type err ::
@@ -117,7 +119,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
               "use_codeowners",
               false
             ),
-          committer: committer
+          committer: committer,
+          update_base_for_deletes: Map.get(toml, "update_base_for_deletes", false)
         }
 
         case toml do

--- a/lib/worker/branch_deleter.ex
+++ b/lib/worker/branch_deleter.ex
@@ -84,15 +84,26 @@ defmodule BorsNG.Worker.BranchDeleter do
     pr_squash_merged = String.starts_with?(pr.title, "[Merged by Bors] - ")
 
     if pr_in_same_repo && delete_merged_branches do
-      cond do
-        pr.merged ->
-          GitHub.delete_branch!(conn, pr.head_ref)
+      delete =
+        cond do
+          pr.merged ->
+            true
 
-        pr_closed && pr_squash_merged ->
-          GitHub.delete_branch!(conn, pr.head_ref)
+          pr_closed && pr_squash_merged ->
+            true
 
-        true ->
-          nil
+          true ->
+            nil
+        end
+
+      if delete do
+        if update_base_for_deletes do
+          GitHub.get_open_prs_with_base!(conn, pr.head_ref)
+          |> Enum.map(&%{&1 | base_ref: pr.base_ref})
+          |> Enum.map(&GitHub.update_pr!(conn, &1))
+        end
+
+        GitHub.delete_branch!(conn, pr.head_ref)
       end
     end
   end

--- a/lib/worker/branch_deleter.ex
+++ b/lib/worker/branch_deleter.ex
@@ -73,9 +73,9 @@ defmodule BorsNG.Worker.BranchDeleter do
 
     toml_result = Batcher.GetBorsToml.get(conn, pr.head_ref)
 
-    delete_merged_branches =
+    {delete_merged_branches, update_base_for_deletes} =
       case toml_result do
-        {:ok, toml} -> toml.delete_merged_branches
+        {:ok, toml} -> {toml.delete_merged_branches, toml.update_base_for_deletes}
         _ -> false
       end
 


### PR DESCRIPTION
A possible fix for one of the issues in https://github.com/bors-ng/bors-ng/issues/950. 
A proposal RFC for this is at https://forum.bors.tech/t/update-base-branch-of-prs-depending-on-a-branch-that-will-be-deleted/507

This PR adds an opt-in feature where if bors is going to delete a branch (due to a PR being merged), it will first update the base branch of other PRs that depend on it. It does so simply by changing the `base_ref` using the github API. This won't cause changes to the commit history, it will simply keep the dependant PRs open (otherwise they are automatically closed) and showing the new commits only. 