### PR TITLE
Fix codeowners with double asterisk and prefixed with /

### DIFF
--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -112,8 +112,16 @@ defmodule BorsNG.CodeOwnerParser do
 
       String.contains?(file_pattern, double_asterisk) ->
         patterns = String.split(file_pattern, double_asterisk, parts: 2)
+        parent = List.first(patterns)
 
-        String.starts_with?(file_name, List.first(patterns)) &&
+        first_part =
+          if String.starts_with?(parent, "/") do
+            String.starts_with?("/" <> file_name, parent)
+          else
+            String.starts_with?(file_name, List.first(patterns))
+          end
+
+        first_part &&
           String.contains?(file_name, List.last(patterns))
     end
   end

--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -118,7 +118,7 @@ defmodule BorsNG.CodeOwnerParser do
           if String.starts_with?(parent, "/") do
             String.starts_with?("/" <> file_name, parent)
           else
-            String.starts_with?(file_name, List.first(patterns))
+            String.starts_with?(file_name, parent)
           end
 
         first_part &&

--- a/test/parse_owners_test.exs
+++ b/test/parse_owners_test.exs
@@ -197,6 +197,18 @@ defmodule BorsNG.ParseTest do
     assert Enum.count(reviewers) == 1
     assert Enum.count(Enum.at(reviewers, 0)) == 1
     assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/test_team_2"
+
+    files = [
+      %BorsNG.GitHub.File{
+        filename: "docs/path/core"
+      }
+    ]
+
+    reviewers = BorsNG.CodeOwnerParser.list_required_reviews(owner_file, files)
+
+    assert Enum.count(reviewers) == 1
+    assert Enum.count(Enum.at(reviewers, 0)) == 1
+    assert Enum.at(Enum.at(reviewers, 0), 0) == "@my_org/core_team"
   end
 
   test "Test Double Asterisk in the beggining" do

--- a/test/testdata/code_owners_7
+++ b/test/testdata/code_owners_7
@@ -19,3 +19,5 @@ other/** @my_org/other_team
 # "a/x/y/b" and so on.
 src/**/core @my_org/core_team
 src/**/test @my_org/test_team_2
+
+/docs/**/core @my_org/core_team


### PR DESCRIPTION
If the pattern contains a double-asterisk and prefixed with '/', the code failed to parse it correctly.