### PR TITLE
Add PUBLIC_PROTOCOL to allow serving from a HTTP endpoint

### DIFF
--- a/app.json
+++ b/app.json
@@ -24,8 +24,12 @@
       "description": "Where this website will be running (probably <app name>.herokuapp.com)"
     },
     "PUBLIC_PORT": {
-      "description": "HTTPS port number on PUBLIC_HOST",
+      "description": "Port number on PUBLIC_HOST",
       "value": "443"
+    },
+    "PUBLIC_PROTOCOL": {
+      "description": "Protocol to use when connecting to PUBLIC_HOST:PUBLIC_PORT",
+      "value": "https"
     },
     "SECRET_KEY_BASE": {
       "description": "A secret key for verifying the integrity of cookies",

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -11,7 +11,7 @@ config :bors, BorsNG.Endpoint,
   http: [port: {:system, "PORT"}],
   url: [
     host: {:system, "PUBLIC_HOST"},
-    scheme: "https",
+    scheme: {:system, "PUBLIC_PROTOCOL", "https"},
     port: {:system, :integer, "PUBLIC_PORT", 443}
   ],
   check_origin: false,


### PR DESCRIPTION
Closes #1042 

This PR introduces a new environment variable, `PUBLIC_PROTOCOL`. If unset, the value defaults to the current hardcoded value of `https`, with no change in behaviour:

```log
13:46:22.316 pid=<0.2038.0> [info] Running BorsNG.Endpoint with cowboy 1.1.2 at 0.0.0.0:39103 (http)
13:46:22.318 pid=<0.2005.0> [info] Access BorsNG.Endpoint at https://172.17.0.1:39103
```

If `PUBLIC_PROTOCOL=http` is set, the endpoint is updated accordingly:

```log
13:48:59.885 pid=<0.2038.0> [info] Running BorsNG.Endpoint with cowboy 1.1.2 at 0.0.0.0:39103 (http)
13:48:59.887 pid=<0.2005.0> [info] Access BorsNG.Endpoint at http://172.17.0.1:39103
```

This allows the app to run at a HTTP endpoint if HTTPS is not required.