### PR TITLE
When changing squashed PR title, do not update base

### DIFF
--- a/lib/github/github.ex
+++ b/lib/github/github.ex
@@ -59,10 +59,26 @@ defmodule BorsNG.GitHub do
     )
   end
 
+  @spec update_pr_base!(tconn, BorsNG.GitHub.Pr.t()) :: BorsNG.GitHub.Pr.t()
+  def update_pr_base!(repo_conn, pr) do
+    {:ok, pr} = update_pr_base(repo_conn, pr)
+    pr
+  end
+
   @spec update_pr!(tconn, BorsNG.GitHub.Pr.t()) :: BorsNG.GitHub.Pr.t()
   def update_pr!(repo_conn, pr) do
     {:ok, pr} = update_pr(repo_conn, pr)
     pr
+  end
+
+  @spec update_pr_base(tconn, BorsNG.GitHub.Pr.t()) ::
+          {:ok, BorsNG.GitHub.Pr.t()} | {:error, term}
+  def update_pr_base(repo_conn, pr) do
+    GenServer.call(
+      BorsNG.GitHub,
+      {:update_pr_base, repo_conn, pr},
+      Confex.fetch_env!(:bors, :api_github_timeout)
+    )
   end
 
   @spec update_pr(tconn, BorsNG.GitHub.Pr.t()) ::

--- a/lib/github/github/server_mock.ex
+++ b/lib/github/github/server_mock.ex
@@ -174,6 +174,20 @@ defmodule BorsNG.GitHub.ServerMock do
     end
   end
 
+  def do_handle_call(:update_pr_base, repo_conn, pr, state) do
+    with {:ok, repo} <- Map.fetch(state, repo_conn),
+         {:ok, pulls} <- Map.fetch(repo, :pulls) do
+      pulls = %{pulls | pr.number => pr}
+      repo = %{repo | pulls: pulls}
+      state = %{state | repo_conn => repo}
+      {{:ok, pr}, state}
+    end
+    |> case do
+      {{:ok, _}, _} = res -> res
+      _ -> {{:error, :update_pr}, state}
+    end
+  end
+
   def do_handle_call(:get_pr_files, repo_conn, {_pr_xref}, state) do
     files =
       with {:ok, repo} <- Map.fetch(state, repo_conn),

--- a/lib/worker/branch_deleter.ex
+++ b/lib/worker/branch_deleter.ex
@@ -100,7 +100,7 @@ defmodule BorsNG.Worker.BranchDeleter do
         if update_base_for_deletes do
           GitHub.get_open_prs_with_base!(conn, pr.head_ref)
           |> Enum.map(&%{&1 | base_ref: pr.base_ref})
-          |> Enum.map(&GitHub.update_pr!(conn, &1))
+          |> Enum.map(&GitHub.update_pr_base!(conn, &1))
         end
 
         GitHub.delete_branch!(conn, pr.head_ref)


### PR DESCRIPTION
Even if the base is not actually changed, GitHub still gets mad when you try to "change the base ref" on closed Pull Requests.

Fixes #1067