### PR TITLE
Log unknown GitHub events in webhook

### DIFF
--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -91,7 +91,7 @@ defmodule BorsNG.WebhookController do
   end
 
   # Deprecated event, but still being sent since 2020.
-  def do_webhook(conn, "github", "integration_installation") do
+  def do_webhook(_conn, "github", "integration_installation") do
     :ok
   end
 

--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -80,9 +80,10 @@ defmodule BorsNG.WebhookController do
   """
   def webhook(conn, %{"provider" => "github"}) do
     event = hd(get_req_header(conn, "x-github-event"))
+
     case do_webhook(conn, "github", event) do
       :unknown -> conn |> send_resp(404, "")
-      _        -> conn |> send_resp(200, "")
+      _ -> conn |> send_resp(200, "")
     end
   end
 

--- a/lib/web/controllers/webhook_controller.ex
+++ b/lib/web/controllers/webhook_controller.ex
@@ -80,10 +80,10 @@ defmodule BorsNG.WebhookController do
   """
   def webhook(conn, %{"provider" => "github"}) do
     event = hd(get_req_header(conn, "x-github-event"))
-    do_webhook(conn, "github", event)
-
-    conn
-    |> send_resp(200, "")
+    case do_webhook(conn, "github", event) do
+      :unknown -> conn |> send_resp(404, "")
+      _        -> conn |> send_resp(200, "")
+    end
   end
 
   def do_webhook(_conn, "github", "ping") do
@@ -306,6 +306,11 @@ defmodule BorsNG.WebhookController do
     Batcher.status(batcher, {commit, identifier, state, url})
     attemptor = Attemptor.Registry.get(project.id)
     Attemptor.status(attemptor, {commit, identifier, state, url})
+  end
+
+  def do_webhook(_conn, "github", event) do
+    Logger.info(["WebhookController: Got unknown Github event: ", event])
+    :unknown
   end
 
   def do_webhook_installation_sync(conn) do


### PR DESCRIPTION
While troubleshooting an issue, I see in our logs.

```
    ** (FunctionClauseError) no function clause matching in BorsNG.WebhookController.do_webhook/3
```

Unfortunately the error that follows shows only the first argument `conn` truncated and not the important second and third arguments.

## Solution

Similar to `do_webhook_pr`, I've added a `do_webhook` clause to log the unknown cases. I have it return a 404 (so its close to the previous behaviour of returning a 500) but suggestions for a different behaviour are welcome.

## Test

Tested by running

```
curl -X POST localhost:8000/webhook/github -H 'x-github-event: bogus' -d "{}"
```

with signature checking temporarily disabled and saw

```
[info] WebhookController: Got unknown Github event: bogus
```

in the server output.