### PR TITLE
Fix MatchError from wrong number of values returned.

### DIFF
--- a/lib/worker/branch_deleter.ex
+++ b/lib/worker/branch_deleter.ex
@@ -76,7 +76,7 @@ defmodule BorsNG.Worker.BranchDeleter do
     {delete_merged_branches, update_base_for_deletes} =
       case toml_result do
         {:ok, toml} -> {toml.delete_merged_branches, toml.update_base_for_deletes}
-        _ -> false
+        _ -> {false, false}
       end
 
     pr_closed = pr.state == :closed


### PR DESCRIPTION
In commit 9c555f8cec72fe1891429534d5dd81d7c436fc18, the result of the first branch in

```
      case toml_result do
        {:ok, toml} -> {toml.delete_merged_branches, toml.update_base_for_deletes}
        _ -> false
      end
```

is updated but not the second branch, resulting in a MatchError.

This small PR fixes that.