### PR TITLE
Send a message on GitHub when a duplicate preflight poll terminates.

### DIFF
--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -43,6 +43,10 @@ defmodule BorsNG.Worker.Batcher.Message do
     "All preflight checks passed. Batching this PR into the staging branch."
   end
 
+  def generate_message({:preflight, :duplicate}) do
+    "Stopped waiting for PR status (Github check) without running due to duplicate requests to run. You may check Bors to see that this PR is included in a batch by one of the other requests."
+  end
+
   def generate_message({:preflight, :timeout}) do
     "GitHub status checks took too long to complete, so bors is giving up. You can adjust bors configuration to have it wait longer if you like."
   end

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -1160,6 +1160,8 @@ defmodule BorsNG.Worker.BatcherTest do
                commits: %{},
                comments: %{
                  1 => [
+                   "Stopped waiting for PR status (Github check) without running due to duplicate requests to run. You may check Bors to see that this PR is included in a batch by one of the other requests.",
+                   "Stopped waiting for PR status (Github check) without running due to duplicate requests to run. You may check Bors to see that this PR is included in a batch by one of the other requests.",
                    ":clock1: Waiting for PR status (Github check) to be set, probably by CI. Bors will automatically try to run when all required PR statuses are set."
                  ]
                },


### PR DESCRIPTION
Gonna preface this by saying I'm not super sure about this one.

## Background

I'm trying to track down why the prefilight poll sometimes terminates when there are no duplicates. Excerpt from the logs.

```
[info] Continue Poll Patch 10349 prerun
[info] Code review status: Label Check true Passed Status: false Passed Review: sufficient CODEOWNERS: true Passed Up-To-Date Review: sufficient
<Some GitHub webhooks happen>
[info] Continue Poll Patch 10349 prerun
[info] Patch 10349 already left prerun, exiting prerun poll loop
```

I see the extra `already left prerun` check was added in #841 and its only supposed to remove duplicate `bors r+/merge` requests. But I don't see any duplicate requests here: the timestamps of `Continue Poll` are about a minute apart and there are no new `Start Poll Patch`).

I see other cases where Bors comments with "Waiting for PR Status" and then doesn't comment again (or merge) and suspect is a similar issue, but the logs are too far back and we don't have then anymore.

Since the polling silently stops, its quite frustrating for devs who have to `bors r+` again.

## Solution

In this PR, Bors adds a GitHub comment when it stops polling due to duplicates. This should both inform devs and help track down this issue.

## Drawbacks

This add an extra comment from Bors, which may sometimes be confusing. But if people made multiple requests, they should understand the messages referring to duplicates. It is only in the case where the preflight polling stopped due to something else where the message would be confusing. But I'm thinking even in that case, its better they are informed.