### PR TITLE
Fix crash on self_check because of trying to start multiple process

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -78,6 +78,7 @@ defmodule BorsNG.Worker.Batcher do
   # Server callbacks
 
   def init(project_id) do
+    BorsNG.Worker.Batcher.Registry.monitor(self(), project_id)
     Process.send_after(
       self(),
       {:poll, :repeat},

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -79,6 +79,7 @@ defmodule BorsNG.Worker.Batcher do
 
   def init(project_id) do
     BorsNG.Worker.Batcher.Registry.monitor(self(), project_id)
+
     Process.send_after(
       self(),
       {:poll, :repeat},

--- a/lib/worker/batcher/registry.ex
+++ b/lib/worker/batcher/registry.ex
@@ -18,6 +18,8 @@ defmodule BorsNG.Worker.Batcher.Registry do
   alias BorsNG.Database.Project
   alias BorsNG.Database.Repo
 
+  require Logger
+
   @name BorsNG.Worker.Batcher.Registry
 
   # Public API
@@ -26,27 +28,43 @@ defmodule BorsNG.Worker.Batcher.Registry do
     GenServer.start_link(__MODULE__, :ok, name: @name)
   end
 
-  def get(project_id) when is_integer(project_id) do
-    GenServer.call(@name, {:get, project_id})
+  def get(project_id, 5) when is_integer(project_id) do
+    pid = GenServer.call(@name, {:get, project_id})
+    # process haven't been started at all
+    if pid == nil do
+      do_start(project_id)
+    end
+  end
+
+  def get(project_id, count \\ 0) when is_integer(project_id) do
+    pid = GenServer.call(@name, {:get, project_id})
+
+    if pid == nil do
+      # broadcasted message from Batcher to registry hasn't been processed
+      # we give chance them to register before trying to create a new one
+      Process.sleep(100)
+      get(project_id, count + 1)
+    else
+      pid
+    end
+  end
+
+  def monitor(pid, project_id) do
+    GenServer.cast(@name, {:monitor, project_id, pid})
   end
 
   # Server callbacks
 
   def init(:ok) do
-    names =
-      Project.active()
+    Project.active()
       |> Repo.all()
       |> Enum.map(fn %{id: id} -> id end)
       |> Enum.uniq()
       |> Enum.map(&{&1, do_start(&1)})
-      |> Map.new()
 
-    refs =
-      names
-      |> Enum.map(&{Process.monitor(elem(&1, 1)), elem(&1, 0)})
-      |> Map.new()
-
-    {:ok, {names, refs}}
+    # When the worker actually started, they'll register them self to the
+    # registry using monitor.
+    {:ok, {Map.new(), Map.new()}}
   end
 
   def do_start(project_id) do
@@ -54,25 +72,39 @@ defmodule BorsNG.Worker.Batcher.Registry do
     pid
   end
 
-  def start_and_insert(project_id, {names, refs}) do
-    pid = do_start(project_id)
-    names = Map.put(names, project_id, pid)
-    ref = Process.monitor(pid)
-    refs = Map.put(refs, ref, project_id)
-    {pid, {names, refs}}
-  end
-
   def handle_call({:get, project_id}, _from, {names, _refs} = state) do
     {pid, state} =
       case names[project_id] do
         nil ->
-          start_and_insert(project_id, state)
+          {nil, state}
 
         pid ->
           {pid, state}
       end
 
     {:reply, pid, state}
+  end
+
+  def handle_cast({:monitor, project_id, pid}, {names, refs} = state) do
+    new_state =
+      case names[project_id] do
+        nil ->
+          ref = Process.monitor(pid)
+          names = Map.put(names, project_id, pid)
+          refs = Map.put(refs, ref, project_id)
+          {names, refs}
+
+        pid ->
+          Logger.warning(
+            "Project #{inspect(project_id)} already monitored #{inspect(pid)} by #{
+              inspect(names[project_id])
+            }"
+          )
+
+          state
+      end
+
+    {:noreply, new_state}
   end
 
   def handle_info({:DOWN, ref, :process, pid, :normal}, {names, refs}) do
@@ -89,6 +121,12 @@ defmodule BorsNG.Worker.Batcher.Registry do
   end
 
   def handle_info({:DOWN, ref, :process, pid, reason}, {names, refs}) do
+    Logger.warn(
+      "Batcher #{inspect(pid)} for project #{inspect(refs[ref])} crashed with state #{
+        inspect({names, refs})
+      }"
+    )
+
     {project_id, refs} = Map.pop(refs, ref)
 
     names =

--- a/lib/worker/batcher/registry.ex
+++ b/lib/worker/batcher/registry.ex
@@ -95,7 +95,7 @@ defmodule BorsNG.Worker.Batcher.Registry do
           {names, refs}
 
         pid ->
-          Logger.warning(
+          Logger.warn(
             "Project #{inspect(project_id)} already monitored #{inspect(pid)} by #{
               inspect(names[project_id])
             }"

--- a/lib/worker/batcher/registry.ex
+++ b/lib/worker/batcher/registry.ex
@@ -57,10 +57,10 @@ defmodule BorsNG.Worker.Batcher.Registry do
 
   def init(:ok) do
     Project.active()
-      |> Repo.all()
-      |> Enum.map(fn %{id: id} -> id end)
-      |> Enum.uniq()
-      |> Enum.map(&{&1, do_start(&1)})
+    |> Repo.all()
+    |> Enum.map(fn %{id: id} -> id end)
+    |> Enum.uniq()
+    |> Enum.map(&{&1, do_start(&1)})
 
     # When the worker actually started, they'll register them self to the
     # registry using monitor.


### PR DESCRIPTION
This change will remove `check_self` crash.

It hasn't been tested outside of the private fork.

Fixing this because unable to resolve #1085.