### PR TITLE
Fix CODEOWNERS failure due to hardcoded "master"

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -992,7 +992,7 @@ defmodule BorsNG.Worker.Batcher do
       true
     else
       Logger.info("Checking code owners")
-      {:ok, code_owner} = Batcher.GetCodeOwners.get(repo_conn, "master")
+      {:ok, code_owner} = Batcher.GetCodeOwners.get(repo_conn, patch.commit)
       Logger.info("CODEOWNERS file #{inspect(code_owner)}")
 
       {:ok, files} = GitHub.get_pr_files(repo_conn, patch.pr_xref)

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -992,7 +992,7 @@ defmodule BorsNG.Worker.Batcher do
       true
     else
       Logger.info("Checking code owners")
-      {:ok, code_owner} = Batcher.GetCodeOwners.get(repo_conn, patch.commit)
+      {:ok, code_owner} = Batcher.GetCodeOwners.get(repo_conn, patch.into_branch)
       Logger.info("CODEOWNERS file #{inspect(code_owner)}")
 
       {:ok, files} = GitHub.get_pr_files(repo_conn, patch.pr_xref)


### PR DESCRIPTION
Our repository does not use `master` as the mainline for bors. Bors is erroneously passing the codeowners check, and in the logs it would get a 404: 
```
[error] GET https://api.github.com/repositories/123456/contents/.github/CODEOWNERS -> 404 (127.281 ms)
```

**I have not tested this PR**. I do not know Elixir, but this seems to be a good starting point for a change. An improvement could be that if `use_codeowners` is true and the http request fails, the codeowners check should fail.

Hopefully this is a good jumping off point. My coworker knows Elixir and has contributed in the past, so maybe they can get this PR into a better state if it's not acceptable as-is :)