### PR TITLE
Get rid of transaction around contributor sync

### DIFF
--- a/lib/worker/syncer.ex
+++ b/lib/worker/syncer.ex
@@ -57,17 +57,15 @@ defmodule BorsNG.Worker.Syncer do
       |> Enum.filter(fn %{perms: perms} -> perms[github_perm] end)
       |> Enum.map(fn %{user: user} -> user end)
 
-    Repo.transaction(fn ->
-      saved_users =
-        authorized_users
-        |> Enum.map(&Syncer.sync_user/1)
+    saved_users =
+      authorized_users
+      |> Enum.map(&Syncer.sync_user/1)
 
-      project
-      |> Repo.preload(association)
-      |> Ecto.Changeset.change()
-      |> Ecto.Changeset.put_assoc(association, saved_users)
-      |> Repo.update!()
-    end)
+    project
+    |> Repo.preload(association)
+    |> Ecto.Changeset.change()
+    |> Ecto.Changeset.put_assoc(association, saved_users)
+    |> Repo.update()
   end
 
   def synchronize_project_collaborators_by_role(project, _, _, nil) do


### PR DESCRIPTION
It's not really necessary. If it winds up half-way done, it'll still be recoverable.

https://forum.bors.tech/t/postgres-timeout-error-with-large-github-organization/544