### PR TITLE
Make the database timeout configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ All the same recommendations apply, with some extra notes:
 - `ELIXIR_VERSION` can be set as a build-time argument. Its default value is defined in the [Dockerfile](Dockerfile).
 - `ALLOW_PRIVATE_REPOS` must be set at both build and run times to take effect. It is set to ` true` by default.
 - `DATABASE_URL` *must* contain the database port, as it will be used at container startup to wait until the database is reachable. [The format is documented here](https://hexdocs.pm/ecto/Ecto.Repo.html#module-urls).
+- `DATABASE_TIMEOUT` may be set higher than the default of `15_000`(ms). This may be necessary with repositories with a very large amount of members.
 - The database schema will be automatically created and migrated at container startup, unless the ` DATABASE_AUTO_MIGRATE`  env. var.
   is set to `false`. Make that change if the database state is managed externally, or if you are using a database that cannot safely handle
   concurrent schema changes (such as older MariaDB/MySQL versions).

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -3,6 +3,7 @@ use Mix.Config
 config :bors, BorsNG.Database.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: {:system, "DATABASE_URL"},
+  timeout: {:system, :integer, "DATABASE_TIMEOUT", 15_000},
   pool_size: {:system, :integer, "POOL_SIZE", 10},
   loggers: [{Ecto.LogEntry, :log, []}],
   ssl: {:system, :boolean, "DATABASE_USE_SSL", true}


### PR DESCRIPTION
Add the ability to configure the database timeout using an environment variable.
The default value remains at 15 seconds, but for repositories with 1000s of users, making the value configurable avoids running into issues.

#1133 already helped, but we have still seen some timeouts adding users.