### PR TITLE
Support all of the CODEOWNERS locations documented by GitHub

### DIFF
--- a/lib/worker/batcher/get_code_owners.ex
+++ b/lib/worker/batcher/get_code_owners.ex
@@ -9,7 +9,10 @@ defmodule BorsNG.Worker.Batcher.GetCodeOwners do
 
   @spec get(GitHub.tconn(), binary) :: {:ok, BorsNG.CodeOwners.t()} | {:error, terror}
   def get(repo_conn, branch) do
-    file = GitHub.get_file!(repo_conn, branch, ".github/CODEOWNERS")
+    file =
+      Enum.find_value(["CODEOWNERS", "docs/CODEOWNERS", ".github/CODEOWNERS"], fn path ->
+        GitHub.get_file!(repo_conn, branch, path)
+      end)
 
     BorsNG.CodeOwnerParser.parse_file(file)
   end

--- a/test/batcher/batcher_test.exs
+++ b/test/batcher/batcher_test.exs
@@ -605,6 +605,216 @@ defmodule BorsNG.Worker.BatcherTest do
     assert [] == Repo.all(Batch)
   end
 
+  test "rejects a patch with missing require reviewers - path docs/CODEOWNERS", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{1 => []},
+        teams: %{
+          "my_org" => %{
+            "my_team" => %{}
+          }
+        },
+        statuses: %{"Z" => %{"cn" => :ok}},
+        pulls: %{
+          1 => %Pr{
+            number: 1,
+            title: "Test",
+            body: "Mess",
+            state: :open,
+            base_ref: "master",
+            head_sha: "00000001",
+            head_ref: "update",
+            base_repo_id: 14,
+            head_repo_id: 14,
+            merged: false
+          }
+        },
+        reviews: %{1 => %{"APPROVED" => 0, "CHANGES_REQUESTED" => 0, "approvers" => []}},
+        files: %{
+          "Z" => %{
+            "bors.toml" => ~s"""
+            status = [ "ci" ]
+            pr_status = [ "cn" ]
+            use_codeowners = true
+            """
+          },
+          "master" => %{
+            "docs/CODEOWNERS" => ~s"""
+            bors.toml               @my_org/my_team
+            """
+          }
+        }
+      }
+    })
+
+    patch =
+      %Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "Z",
+        into_branch: "master"
+      }
+      |> Repo.insert!()
+
+    Batcher.handle_cast({:reviewed, patch.id, "rvrr"}, proj.id)
+    state = GitHub.ServerMock.get_state()
+
+    assert state == %{
+             {{:installation, 91}, 14} => %{
+               branches: %{},
+               commits: %{},
+               teams: %{
+                 "my_org" => %{
+                   "my_team" => %{}
+                 }
+               },
+               pulls: %{
+                 1 => %Pr{
+                   number: 1,
+                   title: "Test",
+                   body: "Mess",
+                   state: :open,
+                   base_ref: "master",
+                   head_sha: "00000001",
+                   head_ref: "update",
+                   base_repo_id: 14,
+                   head_repo_id: 14,
+                   merged: false
+                 }
+               },
+               comments: %{
+                 1 => [":-1: Rejected because of missing code owner approval"]
+               },
+               statuses: %{"Z" => %{"cn" => :ok}},
+               files: %{
+                 "Z" => %{
+                   "bors.toml" => ~s"""
+                   status = [ "ci" ]
+                   pr_status = [ "cn" ]
+                   use_codeowners = true
+                   """
+                 },
+                 "master" => %{
+                   "docs/CODEOWNERS" => ~s"""
+                   bors.toml               @my_org/my_team
+                   """
+                 }
+               },
+               reviews: %{1 => %{"APPROVED" => 0, "CHANGES_REQUESTED" => 0, "approvers" => []}}
+             }
+           }
+
+    # When preflight checks reject a patch, no batch should be created!
+    assert [] == Repo.all(Batch)
+  end
+
+  test "rejects a patch with missing require reviewers - path CODEOWNERS", %{proj: proj} do
+    GitHub.ServerMock.put_state(%{
+      {{:installation, 91}, 14} => %{
+        branches: %{},
+        commits: %{},
+        comments: %{1 => []},
+        teams: %{
+          "my_org" => %{
+            "my_team" => %{}
+          }
+        },
+        statuses: %{"Z" => %{"cn" => :ok}},
+        pulls: %{
+          1 => %Pr{
+            number: 1,
+            title: "Test",
+            body: "Mess",
+            state: :open,
+            base_ref: "master",
+            head_sha: "00000001",
+            head_ref: "update",
+            base_repo_id: 14,
+            head_repo_id: 14,
+            merged: false
+          }
+        },
+        reviews: %{1 => %{"APPROVED" => 0, "CHANGES_REQUESTED" => 0, "approvers" => []}},
+        files: %{
+          "Z" => %{
+            "bors.toml" => ~s"""
+            status = [ "ci" ]
+            pr_status = [ "cn" ]
+            use_codeowners = true
+            """
+          },
+          "master" => %{
+            "CODEOWNERS" => ~s"""
+            bors.toml               @my_org/my_team
+            """
+          }
+        }
+      }
+    })
+
+    patch =
+      %Patch{
+        project_id: proj.id,
+        pr_xref: 1,
+        commit: "Z",
+        into_branch: "master"
+      }
+      |> Repo.insert!()
+
+    Batcher.handle_cast({:reviewed, patch.id, "rvrr"}, proj.id)
+    state = GitHub.ServerMock.get_state()
+
+    assert state == %{
+             {{:installation, 91}, 14} => %{
+               branches: %{},
+               commits: %{},
+               teams: %{
+                 "my_org" => %{
+                   "my_team" => %{}
+                 }
+               },
+               pulls: %{
+                 1 => %Pr{
+                   number: 1,
+                   title: "Test",
+                   body: "Mess",
+                   state: :open,
+                   base_ref: "master",
+                   head_sha: "00000001",
+                   head_ref: "update",
+                   base_repo_id: 14,
+                   head_repo_id: 14,
+                   merged: false
+                 }
+               },
+               comments: %{
+                 1 => [":-1: Rejected because of missing code owner approval"]
+               },
+               statuses: %{"Z" => %{"cn" => :ok}},
+               files: %{
+                 "Z" => %{
+                   "bors.toml" => ~s"""
+                   status = [ "ci" ]
+                   pr_status = [ "cn" ]
+                   use_codeowners = true
+                   """
+                 },
+                 "master" => %{
+                   "CODEOWNERS" => ~s"""
+                   bors.toml               @my_org/my_team
+                   """
+                 }
+               },
+               reviews: %{1 => %{"APPROVED" => 0, "CHANGES_REQUESTED" => 0, "approvers" => []}}
+             }
+           }
+
+    # When preflight checks reject a patch, no batch should be created!
+    assert [] == Repo.all(Batch)
+  end
+
   test "rejects a patch with missing require reviewers - using prefix in CODEOWNERS", %{
     proj: proj
   } do


### PR DESCRIPTION
As documented [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-file-location), GitHub supports `CODEOWNERS` in the root, `docs/`, or `.github/` directory of a repo.

Fixes #803