### PR TITLE
Log required_reviewers to allow debugging failing CODEOWNER checks

### DIFF
--- a/lib/github/parse_owner.ex
+++ b/lib/github/parse_owner.ex
@@ -92,7 +92,7 @@ defmodule BorsNG.CodeOwnerParser do
       |> Enum.filter(fn x -> Enum.count(x) > 0 end)
       |> Enum.uniq()
 
-    Logger.debug("Required reviewers: #{inspect(required_reviewers)}")
+    Logger.info("Required reviewers: #{inspect(required_reviewers)}")
 
     required_reviewers
   end


### PR DESCRIPTION
We're still seeing mismatches between GitHub's and Bors' handling of
CODEOWNERS. Logging the `required_reviewers` should make it easier to
debug these cases.