### PR TITLE
Update the erlang package to Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,7 @@ RUN if [ -d .git ]; then \
 
 ####
 
-FROM debian:stretch-slim
+FROM debian:buster-slim
 RUN apt-get update -q && apt-get --no-install-recommends install -y git-core libssl1.1 curl apt-utils ca-certificates
 
 ENV DOCKERIZE_VERSION=v0.6.0


### PR DESCRIPTION
The [elixir 1.11 image] is based on erlang 23, and the [erlang 23 image] is based on buster.

Fixes #1183

[elixir 1.11 image]: https://github.com/erlef/docker-elixir/blob/596458698bd8febec1ce35aca04e86e22b0aa2c7/1.11/Dockerfile
[erlang 23 image]: https://github.com/erlang/docker-erlang-otp/blob/8098a3fa55d00b9c6db33dd9721f59c5777abbc2/23/Dockerfile