### PR TITLE
Add cancel as an alias for bors r-

### DIFF
--- a/lib/web/command.ex
+++ b/lib/web/command.ex
@@ -162,6 +162,7 @@ defmodule BorsNG.Command do
   def parse_cmd("ping" <> _), do: [:ping]
   def parse_cmd("p=" <> rest), do: parse_priority(rest)
   def parse_cmd("retry" <> _), do: [:retry]
+  def parse_cmd("cancel" <> _), do: [:deactivate]
   def parse_cmd(_), do: []
 
   @doc ~S"""

--- a/test/command_test.exs
+++ b/test/command_test.exs
@@ -47,6 +47,7 @@ defmodule BorsNG.CommandTest do
     assert [:activate] == Command.parse("bors merge")
     assert [:deactivate] == Command.parse("bors r-")
     assert [:deactivate] == Command.parse("bors merge-")
+    assert [:deactivate] == Command.parse("bors cancel")
   end
 
   test "accept the case insensity bare command" do
@@ -55,6 +56,7 @@ defmodule BorsNG.CommandTest do
     assert [:activate] == Command.parse("Bors merge")
     assert [:deactivate] == Command.parse("Bors r-")
     assert [:deactivate] == Command.parse("Bors merge-")
+    assert [:deactivate] == Command.parse("Bors cancel")
   end
 
   test "accept single patch" do
@@ -119,6 +121,7 @@ defmodule BorsNG.CommandTest do
     assert [:activate] == Command.parse("bors: merge")
     assert [:deactivate] == Command.parse("bors: r-")
     assert [:deactivate] == Command.parse("bors: merge-")
+    assert [:deactivate] == Command.parse("bors: cancel")
   end
 
   test "accept the try command with an argument" do
@@ -507,12 +510,14 @@ defmodule BorsNG.CommandTest do
     assert [] == Command.parse("bors merge")
     assert [] == Command.parse("bors r-")
     assert [] == Command.parse("bors merge-")
+    assert [] == Command.parse("bors cancel")
 
     assert [{:try, ""}] == Command.parse("popo try")
     assert [:activate] == Command.parse("popo r+")
     assert [:activate] == Command.parse("popo merge")
     assert [:deactivate] == Command.parse("popo r-")
     assert [:deactivate] == Command.parse("popo merge-")
+    assert [:deactivate] == Command.parse("popo cancel")
 
     if old_env do
       System.put_env("COMMAND_TRIGGER", old_env)


### PR DESCRIPTION
This pr adds the alias `cancel` for `r-`

Fixes #1170