### PR TITLE
Update dockerignore to include all files/dirs from gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,15 @@
 _build
 deps
+/node_modules
+/assets/node_modules
+/doc
+erl_crash.dump
+**/_build
+/db
+**/deps
+/*.ez
+/.deliver/releases/
+/.idea
+/*.iml
+/projectFilesBackup
+/projectFilesBackup1


### PR DESCRIPTION
This change updates the .dockerignore to include all the same files and directories as the .gitignore. The idea here is that if it isn't in the repository, then it shouldn't be required to build Bors. 

Fixes #1199 