### PR TITLE
Helm chart to deploy Bors and Terraform examples 

### DIFF
--- a/.github/workflows/config/chart-lint.yaml
+++ b/.github/workflows/config/chart-lint.yaml
@@ -1,0 +1,5 @@
+chart-dirs:
+  - deploy/charts
+
+chart-repos:
+  - bitnami=https://charts.bitnami.com/bitnami

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,17 +26,17 @@ jobs:
           - elixir: "1.10.0"
             otp_release: "22.0"
     steps:
-    - uses: actions/checkout@master
-    - uses: erlef/setup-elixir@v1
-      with:
-        otp-version: ${{ matrix.otp_release }}
-        elixir-version: ${{ matrix.elixir }}
-    - run: mix deps.get
-      env:
-        BORS_TEST_DATABASE: ${{ matrix.database }}
-    - run: mix test
-      env:
-        BORS_TEST_DATABASE: ${{ matrix.database }}
+      - uses: actions/checkout@master
+      - uses: erlef/setup-elixir@v1
+        with:
+          otp-version: ${{ matrix.otp_release }}
+          elixir-version: ${{ matrix.elixir }}
+      - run: mix deps.get
+        env:
+          BORS_TEST_DATABASE: ${{ matrix.database }}
+      - run: mix test
+        env:
+          BORS_TEST_DATABASE: ${{ matrix.database }}
     services:
       postgresql:
         image: postgres:13
@@ -59,12 +59,12 @@ jobs:
     name: exfmt
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: erlef/setup-elixir@v1
-      with:
-        otp-version: "23.2"
-        elixir-version: "1.11.0"
-    - run: mix format --check-formatted
+      - uses: actions/checkout@master
+      - uses: erlef/setup-elixir@v1
+        with:
+          otp-version: "23.2"
+          elixir-version: "1.11.0"
+      - run: mix format --check-formatted
 
   ci-success:
     name: ci
@@ -76,3 +76,41 @@ jobs:
     steps:
       - name: CI succeeded
         run: exit 0
+
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.5.3
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --chart-dirs deploy/charts
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --chart-dirs deploy/charts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,9 +108,10 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --config .github/workflows/config/chart-lint.yaml
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
-        if: steps.list-changed.outputs.changed == 'true'
-
-      - name: Run chart-testing (install)
-        run: ct install --config .github/workflows/config/chart-lint.yaml
+      # Disable for now becuase Bors requires the Github application to exists
+      # - name: Create kind cluster
+      #   uses: helm/kind-action@v1.1.0
+      #   if: steps.list-changed.outputs.changed == 'true'
+      #
+      # - name: Run chart-testing (install)
+      #   run: ct install --config .github/workflows/config/chart-lint.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,11 +106,11 @@ jobs:
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint --chart-dirs deploy/charts
+        run: ct lint --config .github/workflows/config/chart-lint.yaml
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.0.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install --chart-dirs deploy/charts
+        run: ct install --config .github/workflows/config/chart-lint.yaml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --config .github/workflows/config/chart-lint.yaml)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
@@ -109,7 +109,7 @@ jobs:
         run: ct lint --config .github/workflows/config/chart-lint.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.1.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ erl_crash.dump
 /*.iml
 /projectFilesBackup
 /projectFilesBackup1
+
+# Deploy examples
+/deploy/**/*.tgz

--- a/deploy/charts/bors-ng/.helmignore
+++ b/deploy/charts/bors-ng/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/charts/bors-ng/Chart.lock
+++ b/deploy/charts/bors-ng/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: postgresql
+  repository: https://charts.bitnami.com/bitnami
+  version: 10.3.14
+digest: sha256:14c30e99b228de7ddd2f70d9773a864d4a0ede4c846e6847cda345c234710e05
+generated: "2021-03-31T12:05:49.775412787+01:00"

--- a/deploy/charts/bors-ng/Chart.yaml
+++ b/deploy/charts/bors-ng/Chart.yaml
@@ -5,10 +5,9 @@ type: application
 version: 0.1.0
 appVersion: "latest"
 
-maintainers: # (optional)
-  - name: The maintainers name (required for each maintainer)
-    email: The maintainers email (optional for each maintainer)
-    url: A URL for the maintainer (optional for each maintainer)
+# Github users or organisations
+maintainers:
+  - name: "bors-ng"
 
 dependencies:
 - name: postgresql

--- a/deploy/charts/bors-ng/Chart.yaml
+++ b/deploy/charts/bors-ng/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: bors-ng
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
+appVersion: "latest"
+
+maintainers: # (optional)
+  - name: The maintainers name (required for each maintainer)
+    email: The maintainers email (optional for each maintainer)
+    url: A URL for the maintainer (optional for each maintainer)
+
+dependencies:
+- name: postgresql
+  condition: postgresql.enabled
+  version: "10.3.14"
+  repository: https://charts.bitnami.com/bitnami

--- a/deploy/charts/bors-ng/ci/kind-testing-values.yaml
+++ b/deploy/charts/bors-ng/ci/kind-testing-values.yaml
@@ -1,13 +1,12 @@
-
 env:
   - name: "PORT"
     value: "4000"
   - name: "PUBLIC_PORT"
-    value: "443"  # Should be aligned with the ingress and probes
+    value: "443"
   - name: "PUBLIC_PROTOCOL"
-    value: "https"  # Should be aligned with the ingress and probes
+    value: "https"
   - name: "PUBLIC_HOST"
-    value: "bors.local"  # Should be aligned with the ingress and probes
+    value: "bors.local"
   - name: "DATABASE_USE_SSL"
     value: "false"
   - name: "DATABASE_AUTO_MIGRATE"
@@ -17,7 +16,7 @@ env:
   - name: "DATABASE_URL"
     value: "ecto://postgres:borspwd@bors-postgresql:5432/bors_ng"
   - name: "SECRET_KEY_BASE"
-    value: "aaaaaa" # (unique) Salt for cookies yummy!
+    value: "aaaaaa"
 
   # We need values that exists here or the pod crashes.
   # Unit then... `ct install` action is disabled

--- a/deploy/charts/bors-ng/ci/kind-testing-values.yaml
+++ b/deploy/charts/bors-ng/ci/kind-testing-values.yaml
@@ -1,0 +1,39 @@
+
+env:
+  - name: "PORT"
+    value: "4000"
+  - name: "PUBLIC_PORT"
+    value: "443"  # Should be aligned with the ingress and probes
+  - name: "PUBLIC_PROTOCOL"
+    value: "https"  # Should be aligned with the ingress and probes
+  - name: "PUBLIC_HOST"
+    value: "bors.local"  # Should be aligned with the ingress and probes
+  - name: "DATABASE_USE_SSL"
+    value: "false"
+  - name: "DATABASE_AUTO_MIGRATE"
+    value: "true"
+  - name: "COMMAND_TRIGGER"
+    value: "bors"
+  - name: "DATABASE_URL"
+    value: "ecto://postgres:borspwd@bors-postgresql:5432/bors_ng"
+  - name: "SECRET_KEY_BASE"
+    value: "aaaaaa" # (unique) Salt for cookies yummy!
+
+  # We need values that exists here or the pod crashes.
+  # Unit then... `ct install` action is disabled
+  - name: "GITHUB_CLIENT_ID"
+    value: "1111"
+  - name: "GITHUB_CLIENT_SECRET"
+    value: "2222"
+  - name: "GITHUB_INTEGRATION_ID"
+    value: "333"
+  - name: "GITHUB_INTEGRATION_PEM"
+    value: "4444"
+  - name: "GITHUB_WEBHOOK_SECRET"
+    value: "5555"
+
+postgresql:
+  enabled: true
+  postgresqlPassword: borspwd
+  persistence:
+    enabled: false

--- a/deploy/charts/bors-ng/templates/NOTES.txt
+++ b/deploy/charts/bors-ng/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "bors-ng.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "bors-ng.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "bors-ng.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "bors-ng.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/deploy/charts/bors-ng/templates/_helpers.tpl
+++ b/deploy/charts/bors-ng/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "bors-ng.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "bors-ng.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "bors-ng.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "bors-ng.labels" -}}
+helm.sh/chart: {{ include "bors-ng.chart" . }}
+{{ include "bors-ng.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "bors-ng.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "bors-ng.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "bors-ng.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "bors-ng.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/bors-ng/templates/deployment.yaml
+++ b/deploy/charts/bors-ng/templates/deployment.yaml
@@ -1,0 +1,61 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "bors-ng.fullname" . }}
+  labels:
+    {{- include "bors-ng.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "bors-ng.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "bors-ng.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "bors-ng.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}{{ .Values.image.tagDelimiter }}{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            {{- .Values.ports | toYaml | nindent 12 }}
+          livenessProbe:
+            {{- .Values.livenessProbe | toYaml | nindent 12 }}
+          readinessProbe:
+            {{- .Values.readinessProbe | toYaml | nindent 12 }}
+          {{- if .Values.env }}
+          env:
+            {{- .Values.env | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.envFrom }}
+          envFrom:
+            {{- .Values.envFrom | toYaml | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/bors-ng/templates/deployment.yaml
+++ b/deploy/charts/bors-ng/templates/deployment.yaml
@@ -5,7 +5,11 @@ metadata:
   labels:
     {{- include "bors-ng.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicaCount }}
+  # bors does only support 1 replica running at the same time
+  replicas: 1             #
+  strategy:               #
+    type: Recreate        #
+  #########################
   selector:
     matchLabels:
       {{- include "bors-ng.selectorLabels" . | nindent 6 }}

--- a/deploy/charts/bors-ng/templates/deployment.yaml
+++ b/deploy/charts/bors-ng/templates/deployment.yaml
@@ -33,10 +33,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             {{- .Values.ports | toYaml | nindent 12 }}
+          {{- if .Values.livenessProbe }}
           livenessProbe:
             {{- .Values.livenessProbe | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if .Values.readinessProbe }}
           readinessProbe:
             {{- .Values.readinessProbe | toYaml | nindent 12 }}
+          {{- end }}
           {{- if .Values.env }}
           env:
             {{- .Values.env | toYaml | nindent 12 }}

--- a/deploy/charts/bors-ng/templates/ingress.yaml
+++ b/deploy/charts/bors-ng/templates/ingress.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "bors-ng.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "bors-ng.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: {{ .path }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+  {{- end }}

--- a/deploy/charts/bors-ng/templates/service.yaml
+++ b/deploy/charts/bors-ng/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "bors-ng.fullname" . }}
+  labels:
+    {{- include "bors-ng.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "bors-ng.selectorLabels" . | nindent 4 }}

--- a/deploy/charts/bors-ng/templates/serviceaccount.yaml
+++ b/deploy/charts/bors-ng/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bors-ng.serviceAccountName" . }}
+  labels:
+    {{- include "bors-ng.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/charts/bors-ng/values.yaml
+++ b/deploy/charts/bors-ng/values.yaml
@@ -13,19 +13,19 @@ image:
   tagDelimiter: ":"
 
 ports:
-  - name: http # Same as on probes and Service
-    containerPort: 4000 # Same as PORT env variable
+  - name: http  # Same as on probes and Service
+    containerPort: 4000  # Same as PORT env variable
     protocol: TCP
 
 env:
   - name: "PORT"
     value: "4000"
   - name: "PUBLIC_PORT"
-    value: "443" # Should be aligned with the ingress and probes
+    value: "443"  # Should be aligned with the ingress and probes
   - name: "PUBLIC_PROTOCOL"
-    value: "https" # Should be aligned with the ingress and probes
+    value: "https"  # Should be aligned with the ingress and probes
   - name: "PUBLIC_HOST"
-    value: "bors.local" # Should be aligned with the ingress and probes
+    value: "bors.local"  # Should be aligned with the ingress and probes
   - name: "DATABASE_USE_SSL"
     value: "false"
   - name: "DATABASE_AUTO_MIGRATE"
@@ -65,7 +65,7 @@ livenessProbe:
   tcpSocket:
     port: http
 readinessProbe: {}
-    
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""

--- a/deploy/charts/bors-ng/values.yaml
+++ b/deploy/charts/bors-ng/values.yaml
@@ -35,13 +35,13 @@ env:
   # From here these are sensitive values... consider using secrets
   # like... or `envFrom` below
   # - name: "DATABASE_URL"
+  #   value: "ecto://username:password@db_hostname:db_port/bors_ng"
+  # - name: "DATABASE_URL"
   #   valueFrom:
   #     secretKeyRef:
   #       name: <My secret provisioned outside of this chart>
   #       key: <key on the secret to map into this env var>
   #       optional: false
-  # - name: "DATABASE_URL"
-  #   value: "ecto://username:password@db_hotsname:db_port/bors_ng"
   # - name: "SECRET_KEY_BASE"
   #   value: "" # (unique) Salt for cookies yummy!
   # - name: "GITHUB_CLIENT_ID"
@@ -62,8 +62,10 @@ envFrom:
   #     optional: false
 
 livenessProbe:
+  initialDelaySeconds: 30
   tcpSocket:
     port: http
+
 readinessProbe: {}
 
 imagePullSecrets: []
@@ -136,4 +138,4 @@ tolerations: []
 affinity: {}
 
 postgresql:
-  enabled: true
+  enabled: false

--- a/deploy/charts/bors-ng/values.yaml
+++ b/deploy/charts/bors-ng/values.yaml
@@ -1,0 +1,139 @@
+# Default values for bors-ng.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: borsng/bors-ng
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+  # Change to "@" if `tag` format is SHA256
+  tagDelimiter: ":"
+
+ports:
+  - name: http # Same as on probes and Service
+    containerPort: 4000 # Same as PORT env variable
+    protocol: TCP
+
+env:
+  - name: "PORT"
+    value: "4000"
+  - name: "PUBLIC_PORT"
+    value: "443" # Should be aligned with the ingress and probes
+  - name: "PUBLIC_PROTOCOL"
+    value: "https" # Should be aligned with the ingress and probes
+  - name: "PUBLIC_HOST"
+    value: "bors.local" # Should be aligned with the ingress and probes
+  - name: "DATABASE_USE_SSL"
+    value: "false"
+  - name: "DATABASE_AUTO_MIGRATE"
+    value: "true"
+  - name: "COMMAND_TRIGGER"
+    value: "bors"
+  # From here these are sensitive values... consider using secrets
+  # like... or `envFrom` below
+  # - name: "DATABASE_URL"
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: <My secret provisioned outside of this chart>
+  #       key: <key on the secret to map into this env var>
+  #       optional: false
+  # - name: "DATABASE_URL"
+  #   value: "ecto://username:password@db_hotsname:db_port/bors_ng"
+  # - name: "SECRET_KEY_BASE"
+  #   value: "" # (unique) Salt for cookies yummy!
+  # - name: "GITHUB_CLIENT_ID"
+  #   value: ""
+  # - name: "GITHUB_CLIENT_SECRET"
+  #   value: ""
+  # - name: "GITHUB_INTEGRATION_ID"
+  #   value: ""
+  # - name: "GITHUB_INTEGRATION_PEM"
+  #   value: ""
+  # - name: "GITHUB_WEBHOOK_SECRET"
+  #   value: ""
+
+envFrom:
+  []
+  # - secretRef:
+  #     name: <My secret provisioned outside of this chart>
+  #     optional: false
+
+livenessProbe:
+  tcpSocket:
+    port: http
+readinessProbe: {}
+    
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: http
+
+
+# Bors relies on getting these 3 headers for redirections
+# X-Forwarded-Host
+# X-Forwarded-Proto
+# X-Forwarded-Port
+ingress:
+  enabled: false
+  annotations:
+    {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  host: bors.local
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+postgresql:
+  enabled: true

--- a/deploy/charts/bors-ng/values.yaml
+++ b/deploy/charts/bors-ng/values.yaml
@@ -2,8 +2,6 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-replicaCount: 1
-
 image:
   repository: borsng/bors-ng
   pullPolicy: Always

--- a/deploy/charts/bors-ng/values.yaml
+++ b/deploy/charts/bors-ng/values.yaml
@@ -43,7 +43,7 @@ env:
   #       key: <key on the secret to map into this env var>
   #       optional: false
   # - name: "SECRET_KEY_BASE"
-  #   value: "" # (unique) Salt for cookies yummy!
+  #   value: ""  # (unique) Salt for cookies yummy!
   # - name: "GITHUB_CLIENT_ID"
   #   value: ""
   # - name: "GITHUB_CLIENT_SECRET"

--- a/deploy/examples/terraform/bors_helm_provider.tf
+++ b/deploy/examples/terraform/bors_helm_provider.tf
@@ -1,0 +1,59 @@
+locals {
+  bors_db = {
+    hostname = "db"
+    port = 5432
+    username = "user"
+    password = "pssw"
+  }
+  bors_github = {
+    client_id = ""
+    client_id_secret = ""
+    integration_id = ""
+    integration_pem_b64 = base64encode("")
+    webhook_secret = ""
+  }
+
+  ingress_class = ""
+}
+
+resource kubernetes_namespace bors {
+  metadata {
+    name   = "bors"
+  }
+}
+
+resource kubernetes_secret bors {
+  metadata {
+    name      = "bors"
+    namespace = kubernetes_namespace.bors.metadata.0.name
+  }
+  data = {
+    // ecto://postgres:postgres@localhost/ecto_simple
+    "DATABASE_URL"           = "ecto://${local.bors_db.username}:${urlencode(local.bors_db.password)}@${local.bors_db.hostname}:${local.bors_db.port}/bors_ng"
+    "SECRET_KEY_BASE"        = random_password.bors_cookie_salt.result,
+    "GITHUB_CLIENT_ID"       = local.bors_github.client_id
+    "GITHUB_CLIENT_SECRET"   = local.bors_github.client_id_secret
+    "GITHUB_INTEGRATION_ID"  = local.bors_github.integration_id
+    "GITHUB_INTEGRATION_PEM" = local.bors_github.integration_pem_b64
+    "GITHUB_WEBHOOK_SECRET"  = local.bors_github.webhook_secret
+  }
+}
+
+resource helm_release bors {
+  name       = "bors"
+  repository = "<repository>"
+  chart      = "bors-ng"
+  version    = "0.1.0"
+  namespace  = kubernetes_namespace.bors.metadata.0.name
+
+  values = [
+    <<VALUES
+envFrom:
+  - secretRef:
+      name: "${kubernetes_secret.bors.metadata.0.name}"
+      optional: false
+postgresql:
+  enabled: false
+VALUES
+  ]
+}

--- a/deploy/examples/terraform/bors_kubernetes_provider.tf
+++ b/deploy/examples/terraform/bors_kubernetes_provider.tf
@@ -1,0 +1,203 @@
+locals {
+  # Kubernetes matching labels expressions are used by the ReplicaControllers to find the PODs
+  # that belongs to them and assert if they are up to date and Running
+  # This set of labels are not allowed to change when a rolling upgrade happens so they have to remain
+  # unchanged for the life of Deployment
+  #
+  # immutable
+  bors_match_labels = {
+    "app.kubernetes.io/name"       = "bors"
+    "app.kubernetes.io/component"  = "application"
+    "app.kubernetes.io/part-of"    = "bors"
+    "app.kubernetes.io/managed-by" = "Terraform"
+  }
+
+  # The Deployment, POD, Service... related K8s resources with Bors use this group of labels so they are consisntent
+  #
+  # A requirement between the Deployment.spec.selector.match_labels and POD.metadata.labels
+  # is that the POD has to contain the same as the match_labels but it could also be a superset of them
+  # and include more details about the application
+  bors_labels = merge(
+    local.bors_match_labels,
+    {
+      "app.kubernetes.io/version" = "2021-03-23"
+  })
+
+  bors_port            = 4000
+  bors_public_port     = 443
+  bors_public_protocol = "https"
+  bors_hostname        = "bors.${local.cluster_domain}"
+
+  bors_env_vars = {
+    "PORT"                  = local.bors_port
+    "PUBLIC_PORT"           = "${local.bors_public_port}",
+    "PUBLIC_PROTOCOL"       = "${local.bors_public_protocol}",
+    "PUBLIC_HOST"           = local.bors_hostname,
+    "DATABASE_USE_SSL"      = "false",
+    "DATABASE_AUTO_MIGRATE" = "true",
+    "COMMAND_TRIGGER"       = "bors",
+  }
+
+  # docker pull borsng/bors-ng:latest
+  # docker images --digests borsng/bors-ng:latest
+  # Remember to update teh version label ("app.kubernetes.io/version") above with the data
+  # from the sha (below) from the docker image tag "latest" the only one published by bors
+  bors_image_256sha = "sha256:56ce5c32d794de7e993a2c90411daa071f50a162e39de1e4001165810194430e"
+
+  bors_db = {
+    hostname = "db"
+    port = 5432
+    username = "user"
+    password = "pssw"
+  }
+  bors_github = {
+    client_id = ""
+    client_id_secret = ""
+    integration_id = ""
+    integration_pem_b64 = base64encode("")
+    webhook_secret = ""
+  }
+
+  ingress_class = ""
+}
+
+resource random_password bors_cookie_salt {
+  length  = 64
+  special = false
+}
+
+resource kubernetes_namespace bors {
+  metadata {
+    name   = "bors"
+    labels = local.bors_labels
+  }
+}
+
+resource kubernetes_secret bors {
+  metadata {
+    name      = "bors"
+    namespace = kubernetes_namespace.bors.metadata.0.name
+    labels    = local.bors_labels
+  }
+  data = {
+    // ecto://postgres:postgres@localhost/ecto_simple
+    "DATABASE_URL"           = "ecto://${local.bors_db.username}:${urlencode(local.bors_db.password)}@${local.bors_db.hostname}:${local.bors_db.port}/bors_ng"
+    "SECRET_KEY_BASE"        = random_password.bors_cookie_salt.result,
+    "GITHUB_CLIENT_ID"       = local.bors_github.client_id
+    "GITHUB_CLIENT_SECRET"   = local.bors_github.client_id_secret
+    "GITHUB_INTEGRATION_ID"  = local.bors_github.integration_id
+    "GITHUB_INTEGRATION_PEM" = local.bors_github.integration_pem_b64
+    "GITHUB_WEBHOOK_SECRET"  = local.bors_github.webhook_secret
+  }
+}
+
+resource kubernetes_deployment bors {
+  metadata {
+    name      = "bors"
+    namespace = kubernetes_namespace.bors.metadata.0.name
+    labels    = local.bors_labels
+  }
+
+  spec {
+    # Bors does not support clustering
+    replicas = 1
+
+    strategy {
+      type = "Recreate"
+    }
+
+    selector {
+      match_labels = local.bors_match_labels
+    }
+
+    template {
+      metadata {
+        labels = local.bors_labels
+        annotations = {
+          "kubernetes.secret.hash/${kubernetes_secret.bors.metadata.0.name}" = base64encode(join("", values(kubernetes_secret.bors.data)))
+        }
+      }
+
+      spec {
+        container {
+          image             = "borsng/bors-ng@${local.bors_image_256sha}"
+          image_pull_policy = "IfNotPresent"
+          name              = "bors"
+
+          resources {
+            limits {
+              cpu    = "1"
+              memory = "1Gi"
+            }
+            requests {
+              cpu    = "1"
+              memory = "1Gi"
+            }
+          }
+
+          port {
+            name           = "http"
+            container_port = local.bors_port
+          }
+
+          env_from {
+            secret_ref {
+              name = kubernetes_secret.bors.metadata.0.name
+            }
+          }
+
+          dynamic "env" {
+            for_each = local.bors_env_vars
+            content {
+              name  = env.key
+              value = env.value
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+resource kubernetes_service bors {
+  metadata {
+    name      = "bors"
+    namespace = kubernetes_namespace.bors.metadata.0.name
+    labels    = local.bors_labels
+  }
+
+  spec {
+    selector = local.bors_match_labels
+    port {
+      name        = "http"
+      port        = 8080
+      target_port = "http"
+    }
+  }
+}
+
+resource kubernetes_ingress bors {
+  metadata {
+    name      = "bors"
+    namespace = kubernetes_namespace.bors.metadata.0.name
+    labels    = local.bors_labels
+    annotations = {
+      "kubernetes.io/ingress.class" = local.ingress_class
+    }
+  }
+
+  spec {
+    rule {
+      host = local.bors_hostname
+      http {
+        path {
+          backend {
+            service_name = kubernetes_service.bors.metadata.0.name
+            service_port = "http"
+          }
+          path = "/"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I have created a helm chart to deploy `bors` internally on my company

I'd happily add some documentation to the readme file about this and the Terraform examples that I've also used internally

There is another Github action that could be added to host `bors` chart using Github pages
- https://github.com/helm/chart-releaser
- https://github.com/helm/chart-releaser-action
but it requires some configuration from your side to provide the necessary access/secrets
I'd create a new PR after this one is merged for that :D

After publishing the helm chart we could also add it to https://artifacthub.io/ by login and creating an organisation or just adding a repository
