### PR TITLE
Remove old versions of OTP and Elixir from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,15 +14,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        elixir: ["1.8.1", "1.10.0", "1.11.0"]
-        otp_release: ["21.0.9", "22.0", "23.2"]
+        elixir: ["1.10.0", "1.11.0"]
+        otp_release: ["22.0", "23.2"]
         os: [ubuntu-latest]
         database: [postgresql, mysql]
         exclude:
-          - elixir: "1.8.1"
-            otp_release: "22.0"
-          - elixir: "1.8.1"
-            otp_release: "23.2"
           - elixir: "1.10.0"
             otp_release: "22.0"
     steps:


### PR DESCRIPTION
[RFC 332] committed to supporting the two newest versions of OTP and Elixir, so they're not needed now.

[RFC 332]: https://bors.tech/rfcs/0332-elixir-and-erlang-version-update-policy.html