### PR TITLE
batcher: don't crash on push failure, report error response

### DIFF
--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -117,6 +117,20 @@ defmodule BorsNG.Worker.Batcher.Message do
     } (it was a non-fast-forward update). It will be automatically retried."
   end
 
+  def generate_message({:push_failed_unknown_failure, target_branch, raw_error_content}) do
+    """
+    This PR was included in a batch that successfully built, but then failed to merge into #{
+      target_branch
+    }. It will not be retried.
+
+    Additional information:
+
+    ```json
+    #{raw_error_content}
+    ```
+    """
+  end
+
   def generate_message({state, statuses}) do
     is_new_year = get_is_new_year()
 

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -71,6 +71,34 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     assert expected_message == actual_message
   end
 
+  test "generate push failed (non fast-forward) message" do
+    expected_message =
+      "This PR was included in a batch that successfully built, but then failed to merge into main (it was a non-fast-forward update). It will be automatically retried."
+
+    actual_message = Message.generate_message({:push_failed_non_ff, "main"})
+    assert expected_message == actual_message
+  end
+
+  test "generate push failed (unknown) message" do
+    expected_message = """
+    This PR was included in a batch that successfully built, but then failed to merge into main. It will not be retried.
+
+    Additional information:
+
+    ```json
+    {"status": 500, "message": "Internal server error."}
+    ```
+    """
+
+    actual_message =
+      Message.generate_message(
+        {:push_failed_unknown_failure, "main",
+         '{"status": 500, "message": "Internal server error."}'}
+      )
+
+    assert expected_message == actual_message
+  end
+
   test "generate merged into master message" do
     expected_message = "Pull request successfully merged into master.\n\nBuild succeeded:"
     actual_message = Message.generate_message({:merged, :squashed, "master", []})


### PR DESCRIPTION
See: #1152, #1150, #1027, #432, #375

To summarise: once a batch passes, bors will attempt to push the branch. If this fails, bors can crash. This is visible in the logs, but invisible in the relevant PRs:

![image](https://user-images.githubusercontent.com/12255914/122234698-fc76a080-ceb4-11eb-9733-52c2a9b8c312.png)

This PR prevents bors from ever crashing silently as the result of a failed push. bors will instead mark the batch as errored, and push an appropriate message to the affected PRs.

This message will include the raw error response, which often contains further details.

As implemented here, bors will not retry or bisect the batch, as it is expected most failure cases are to do with a config/setup error outside the control of bors. I am open to changing this behaviour if there is strong feeling otherwise, but it is back-compatible in the sense that all current conditions that cause a crash do not trigger a retry of the batch. This PR has the same behaviour, but with a more visible error message.