### PR TITLE
Improve batch details status readability

### DIFF
--- a/lib/web/templates/batch/show.html.eex
+++ b/lib/web/templates/batch/show.html.eex
@@ -21,16 +21,18 @@
 <p>Date: <%= htmlify_naive_datetime(@batch.updated_at) %></p>
 <p>Priority: <%= @batch.priority %></p>
 <p>State: <%= stringify_state(@batch.state) %></p>
-<p>
-  Status:
+<p>Status:</p>
+<ul>
   <%= for status <- @statuses do %>
+  <li>
     <%= if status.url do %>
     <a href="<%= status.url %>"><%= status.identifier %> (<%= stringify_state(status.state) %>)</a>
     <% else %>
     <span><%= status.identifier %> (<%= stringify_state(status.state) %>)</span>
     <% end %>
+  </li>
   <% end %>
-</p>
+</ul>
 <p>
   Pull Requests:
   <%= for patch <- @patches do %>


### PR DESCRIPTION
The current batch details status list is simply a space delimited list
of all statuses. This can be quite difficult to read with more than one
or two statuses. Instead, use an unordered list, with one status per
line to improve readability with many statuses.

**Current**
![current](https://user-images.githubusercontent.com/59583967/133681361-fb56be8a-bde8-460e-a3ae-b8c861bf40a7.png)

**With Unordered List**
![list](https://user-images.githubusercontent.com/59583967/133681428-747a557b-cef0-405e-941b-8d9df78947df.png)

**Empty Unordered List**
![empty](https://user-images.githubusercontent.com/59583967/133681459-6c255416-2aa4-4fbc-849e-2e8098df07ff.png)
