### PR TITLE
Allow disabling database prepared statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ All the same recommendations apply, with some extra notes:
 - `ALLOW_PRIVATE_REPOS` must be set at both build and run times to take effect. It is set to ` true` by default.
 - `DATABASE_URL` *must* contain the database port, as it will be used at container startup to wait until the database is reachable. [The format is documented here](https://hexdocs.pm/ecto/Ecto.Repo.html#module-urls).
 - `DATABASE_TIMEOUT` may be set higher than the default of `15_000`(ms). This may be necessary with repositories with a very large amount of members.
+- `DATABASE_PREPARE_MODE` can be set to to `unnamed` to disable prepared statements, [which is necessary when using a transaction/statement pooler, like pgbouncer](https://github.com/elixir-ecto/postgrex#pgbouncer). It is set to `named` by default.
 - The database schema will be automatically created and migrated at container startup, unless the ` DATABASE_AUTO_MIGRATE`  env. var.
   is set to `false`. Make that change if the database state is managed externally, or if you are using a database that cannot safely handle
   concurrent schema changes (such as older MariaDB/MySQL versions).

--- a/config/prod.secret.exs
+++ b/config/prod.secret.exs
@@ -6,7 +6,8 @@ config :bors, BorsNG.Database.Repo,
   timeout: {:system, :integer, "DATABASE_TIMEOUT", 15_000},
   pool_size: {:system, :integer, "POOL_SIZE", 10},
   loggers: [{Ecto.LogEntry, :log, []}],
-  ssl: {:system, :boolean, "DATABASE_USE_SSL", true}
+  ssl: {:system, :boolean, "DATABASE_USE_SSL", true},
+  prepare: {:system, :atom, "DATABASE_PREPARE_MODE", :named}
 
 config :bors, BorsNG.Endpoint,
   http: [port: {:system, "PORT"}],


### PR DESCRIPTION
Expose Ecto.Adapters.Postgres's `:prepare` [connection option](https://hexdocs.pm/ecto_sql/Ecto.Adapters.Postgres.html#module-connection-options):
via the env var `DATABASE_PREPARE_MODE`:
- `named` (default) preserves the existing behavior of using prepared statements
- `unnamed` prevents Ecto from using prepared statements

This was introduced in Postgrex v0.11.1 and so this config should already be available.

---

When running bors-ng with a Postgres database in Amazon's Aurora Serverless,
one runs into daily connection issues as described in #1239, as Aurora
Serverless automatically [closes connections that are older than 24 hours](
https://aws.amazon.com/blogs/database/best-practices-for-working-with-amazon-aurora-serverless/
):
> Aurora Serverless closes connections that are older than 24 hours. Make sure
> that your connection pool refreshes connections frequently.

Unfortunately, Ecto's connection pool can't be configured to refresh
connections frequently, so one must run a connection pooler between Ecto and the
Postgres database that does have this capability, like PgBouncer.

But, since Ecto itself tries to maintain a connection pool, it will typically
have long-lived sessions, preventing PgBouncer with its default configuration
from aggressively refreshing the connections. One promising mode of PgBouncer
is transaction pooling, which allows PgBouncer to clean up connections after
transactions end, but prevent's Ecto's default behavior of using prepared
statements. The `:prepare` config flag allows disabling this behavior, and was
added specifically for this purpose. See: elixir-ecto/postgrex#156