### PR TITLE
Fetch the full PR object, including the "mergeable" member

### DIFF
--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -716,8 +716,10 @@ defmodule BorsNG.GitHub.Server do
 
     prs =
       Poison.decode!(raw)
-      |> Enum.flat_map(fn element ->
-        element
+      |> Enum.flat_map(fn %{"url" => url} ->
+        "token #{token}"
+        |> tesla_client(@content_type)
+        |> Tesla.get!(url)
         |> GitHub.Pr.from_json()
         |> case do
           {:ok, pr} -> [pr]


### PR DESCRIPTION
The https://api.github.com/repos/bors-ng/bors-ng/pulls?state=open
URL doesn't have a mergeable member in it. We need to fetch
https://api.github.com/repos/bors-ng/bors-ng/pulls/1333
which actually has all the data we need.

Fixes #1329