### PR TITLE
fix(github): respect API timeout at individual HTTP level

### DIFF
--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -957,7 +957,9 @@ defmodule BorsNG.GitHub.Server do
 
     Tesla.client(
       middleware,
-      Tesla.Adapter.Hackney
+      {Tesla.Adapter.Hackney,
+       connect_timeout: Confex.get_env(:bors, :api_github_timeout, 8_000) - 1,
+       recv_timeout: Confex.get_env(:bors, :api_github_timeout, 8_000) - 1}
     )
   end
 end


### PR DESCRIPTION
It would be better to support deadlines, but I don't know how to get
that with the OTP GenServer receive timeouts.

Fixes #1323