### PR TITLE
Ignoring review entries without commit_id

### DIFF
--- a/lib/github/github/reviews.ex
+++ b/lib/github/github/reviews.ex
@@ -55,6 +55,8 @@ defmodule BorsNG.GitHub.Reviews do
   @spec filter_sha!([map], binary) :: [map]
   def filter_sha!(json, sha) do
     json
+    # Ignore reviews without commit_id node
+    |> Enum.filter(fn(review) -> !is_nil(review["commit_id"]) end)
     |> Enum.filter(fn %{"commit_id" => commit_id} -> commit_id == sha end)
   end
 end

--- a/lib/github/github/reviews.ex
+++ b/lib/github/github/reviews.ex
@@ -56,7 +56,7 @@ defmodule BorsNG.GitHub.Reviews do
   def filter_sha!(json, sha) do
     json
     # Ignore reviews without commit_id node
-    |> Enum.filter(fn(review) -> !is_nil(review["commit_id"]) end)
+    |> Enum.filter(fn review -> !is_nil(review["commit_id"]) end)
     |> Enum.filter(fn %{"commit_id" => commit_id} -> commit_id == sha end)
   end
 end

--- a/test/github_reviews_test.exs
+++ b/test/github_reviews_test.exs
@@ -188,4 +188,44 @@ defmodule BorsNG.GitHub.GitHubReviewsTest do
              }
            ]
   end
+
+  test "filter by commit id when review was dismissed or commented only or just don't have commit_id", _ do
+    result =
+      BorsNG.GitHub.Reviews.filter_sha!(
+        [
+          %{
+            "user" => %{"login" => "bert"},
+            "state" => "CHANGES_REQUESTED",
+            "commit_id" => "123"
+          },
+          %{
+            "user" => %{"login" => "ernie"},
+            "state" => "APPROVED",
+            "commit_id" => "456"
+          },
+          %{
+            "user" => %{"login" => "eric"},
+            "state" => "DISMISSED" # force push can dismiss the review and also there is no commit_id
+          },
+          %{
+            "user" => %{"login" => "eric"},
+            "state" => "COMMENTED"
+          },
+          %{
+            "user" => %{"login" => "eric"},
+            "state" => "APPROVED"
+          }
+        ],
+        "456"
+      )
+
+    assert result == [
+             %{
+               "user" => %{"login" => "ernie"},
+               "state" => "APPROVED",
+               "commit_id" => "456"
+             }
+           ]
+  end
+
 end

--- a/test/github_reviews_test.exs
+++ b/test/github_reviews_test.exs
@@ -189,7 +189,8 @@ defmodule BorsNG.GitHub.GitHubReviewsTest do
            ]
   end
 
-  test "filter by commit id when review was dismissed or commented only or just don't have commit_id", _ do
+  test "filter by commit id when review was dismissed or commented only or just don't have commit_id",
+       _ do
     result =
       BorsNG.GitHub.Reviews.filter_sha!(
         [
@@ -205,7 +206,8 @@ defmodule BorsNG.GitHub.GitHubReviewsTest do
           },
           %{
             "user" => %{"login" => "eric"},
-            "state" => "DISMISSED" # force push can dismiss the review and also there is no commit_id
+            # force push can dismiss the review and also there is no commit_id
+            "state" => "DISMISSED"
           },
           %{
             "user" => %{"login" => "eric"},
@@ -227,5 +229,4 @@ defmodule BorsNG.GitHub.GitHubReviewsTest do
              }
            ]
   end
-
 end


### PR DESCRIPTION
Github Enterprise latest versions has more review types, some of them do not have commit_id node, and of course this is causing it to fail.

The test added cover the types of reviews available.
