### PR TITLE
Make the PR title appear inline in the commit message

### DIFF
--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -29,7 +29,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             delete_merged_branches: false,
             use_codeowners: false,
             committer: nil,
-            commit_title: "Merge ${PR_REFS}",
+            commit_title: "Merge ${PR_REFS}: ${PR_TITL}",
             update_base_for_deletes: false
 
   @type tcommitter :: %{
@@ -123,7 +123,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
               false
             ),
           committer: committer,
-          commit_title: Map.get(toml, "commit_title", "Merge ${PR_REFS}"),
+          commit_title: Map.get(toml, "commit_title", "Merge ${PR_REFS}: ${PR_TITL}"),
           update_base_for_deletes: Map.get(toml, "update_base_for_deletes", false)
         }
 

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -171,14 +171,20 @@ defmodule BorsNG.Worker.Batcher.Message do
         patch_links,
         cut_body_after,
         co_authors,
-        template \\ "Merge ${PR_REFS}"
+        template \\ "Merge ${PR_REFS}: ${PR_TITL}"
       ) do
     pr_refs =
       patch_links
       |> Enum.map(&"\##{&1.patch.pr_xref}")
       |> Enum.join(" ")
 
+    pr_titl =
+      patch_links
+      |> Enum.map(&"\##{&1.patch.title}")
+      |> Enum.join(" ")
+
     commit_title = String.replace(template, "${PR_REFS}", pr_refs)
+    commit_title = String.replace(commit_title, "${PR_TITL}", pr_titl)
 
     commit_body =
       Enum.reduce(patch_links, "", fn link, acc ->


### PR DESCRIPTION
Adding the PR title in the commit message would make IMO the git log browsing clearer and easier.

Would that be possible to have this as default and allow to cut it if people want to get rid of it?

I haven't tested this draft PR and probably need some help to make it work if everyone agrees to add this feature :) 