### PR TITLE
Minor style change: Display Batch of pull request links as UL

### DIFF
--- a/lib/web/templates/batch/show.html.eex
+++ b/lib/web/templates/batch/show.html.eex
@@ -35,9 +35,13 @@
 </ul>
 <p>
   Pull Requests:
-  <%= for patch <- @patches do %>
-  <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
-  <% end %>
+  <ul>
+    <%= for patch <- @patches do %>
+    <li>
+      <a href="<%= Confex.fetch_env!(:bors, :html_github_root) %>/<%= @project.name %>/pull/<%= patch.pr_xref %>">#<%= patch.pr_xref %></a>
+    </li>
+    <% end %>
+  </ul>
 </p>
 
 <% else %>


### PR DESCRIPTION
Hey BORS maintainers, this is a really cool project, thanks for making it open source! I hope this random PR is welcome.

Currently the Batch Details page displays links to PRs included in the batch as a series of relatively unformatted links. At a glance it is hard to parse how many PRs are included and to find a specific one you are interested in.

This minor change introduces a `<ul>` tag and wraps each PR in an `<li>` tag for a more visually appealing and more semantically correct structure.

Github also updated the newlines in a lot of places in this file, sorry for the noise that creates:
> We’ve detected the file has mixed line endings. When you commit changes we will normalize them to Windows-style (CRLF).