### PR TITLE
Gitpod fix: Bump Erlang's Ubuntu repository

### DIFF
--- a/script/Dockerfile.gitpod
+++ b/script/Dockerfile.gitpod
@@ -10,9 +10,9 @@ ENV PORT 8000
 ENV DATABASE_URL="postgresql://gitpod@localhost/bors_dev"
 ENV DATABASE_URL_TEST="postgresql://gitpod@localhost/bors_test"
 
-# Download Elixir/OTP and PostgreSQL
+# Download Elixir/OTP
 RUN which rg || (curl -L https://github.com/BurntSushi/ripgrep/releases/download/13.0.0/ripgrep_13.0.0_amd64.deb > /tmp/ripgrep.deb && sudo dpkg -i /tmp/ripgrep.deb); \
-    echo 'deb https://packages.erlang-solutions.com/ubuntu disco contrib' | sudo tee /etc/apt/sources.list.d/erlang.list && \
+    echo 'deb https://packages.erlang-solutions.com/ubuntu focal contrib' | sudo tee /etc/apt/sources.list.d/erlang.list && \
     curl -L https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc > /tmp/erlang_solutions.asc && \
     sudo apt-key add /tmp/erlang_solutions.asc && \
     sudo apt-get update && \


### PR DESCRIPTION
 ### Issues addressed

Error when starting gitpod:

1. Navigate to https://gitpod.io/#https://github.com/bors-ng/bors-ng

2. Observe error:

```
#5 6.300 Some packages could not be installed. This may mean that you have
#5 6.300 requested an impossible situation or if you are using the unstable
#5 6.300 distribution that some required packages have not yet been created
#5 6.300 or been moved out of Incoming.
#5 6.300 The following information may help to resolve the situation:
#5 6.300 
#5 6.300 The following packages have unmet dependencies:
#5 6.376  esl-erlang : Depends: libwxgtk2.8-0 but it is not installable or
#5 6.376                        libwxgtk3.0-0 but it is not installable or
#5 6.376                        libwxgtk3.0-0v5 but it is not installable
```

 ### Summary of changes
Update repo to correct Ubuntu version.

Fixes https://github.com/bors-ng/bors-ng/issues/1570

 ### Test plan
I created a gitpod from this PR and confirmed it booted into Gitpod correctly: https://gitpod.io/#https://github.com/bors-ng/bors-ng/pull/1571

(note that bors doesn't start correctly, but that's a different error. we're getting further than before!)