### PR TITLE
batcher: report status code on push failure

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -732,11 +732,11 @@ defmodule BorsNG.Worker.Batcher do
               {:non_ff}
 
             true ->
-              {:unknown_failure, raw_error_content}
+              {:unknown_failure, 422, raw_error_content}
           end
 
-        {:error, _, _, raw_error_content} ->
-          {:unknown_failure, raw_error_content}
+        {:error, _, status_code, raw_error_content} ->
+          {:unknown_failure, status_code, raw_error_content}
 
         {:ok, _} ->
           {:success}
@@ -777,7 +777,7 @@ defmodule BorsNG.Worker.Batcher do
 
         :error
 
-      {:unknown_failure, raw_error_content} ->
+      {:unknown_failure, status_code, raw_error_content} ->
         # Don't retry the batch. Something is preventing this batch from merging
         # and it's unlikely us retrying would change that.
 
@@ -785,7 +785,7 @@ defmodule BorsNG.Worker.Batcher do
         send_message(
           repo_conn,
           patches,
-          {:push_failed_unknown_failure, batch.into_branch, raw_error_content}
+          {:push_failed_unknown_failure, batch.into_branch, status_code, raw_error_content}
         )
 
         :error

--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -123,13 +123,16 @@ defmodule BorsNG.Worker.Batcher.Message do
     "This PR was included in a batch that successfully built, but then failed to merge into #{target_branch} (it was a non-fast-forward update). It will be automatically retried."
   end
 
-  def generate_message({:push_failed_unknown_failure, target_branch, raw_error_content}) do
+  def generate_message(
+        {:push_failed_unknown_failure, target_branch, status_code, raw_error_content}
+      ) do
     """
     This PR was included in a batch that successfully built, but then failed to merge into #{target_branch}. It will not be retried.
 
     Additional information:
 
     ```json
+    Response status code: #{status_code}
     #{raw_error_content}
     ```
     """

--- a/test/batcher/message_test.exs
+++ b/test/batcher/message_test.exs
@@ -97,13 +97,14 @@ defmodule BorsNG.Worker.BatcherMessageTest do
     Additional information:
 
     ```json
+    Response status code: 500
     {"status": 500, "message": "Internal server error."}
     ```
     """
 
     actual_message =
       Message.generate_message(
-        {:push_failed_unknown_failure, "main",
+        {:push_failed_unknown_failure, "main", 500,
          '{"status": 500, "message": "Internal server error."}'}
       )
 


### PR DESCRIPTION
Follow up to #1273 

As well as reporting the server response, report the HTTP status code of the Github response.

This is useful in cases where the server returns no response:

![image](https://user-images.githubusercontent.com/12255914/212131697-22a60250-b118-4f98-b572-e5543173a1ad.png)
