### PR TITLE
Allow configuring max batch size

### DIFF
--- a/lib/worker/batcher/bors_toml.ex
+++ b/lib/worker/batcher/bors_toml.ex
@@ -30,7 +30,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             use_codeowners: false,
             committer: nil,
             commit_title: "Merge ${PR_REFS}",
-            update_base_for_deletes: false
+            update_base_for_deletes: false,
+            max_batch_size: nil
 
   @type tcommitter :: %{
           name: binary,
@@ -51,7 +52,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           use_codeowners: boolean,
           committer: tcommitter,
           commit_title: binary,
-          update_base_for_deletes: boolean
+          update_base_for_deletes: boolean,
+          max_batch_size: integer | nil
         }
 
   @type err ::
@@ -64,6 +66,7 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
           | :cut_body_after
           | :committer_details
           | :commit_title
+          | :max_batch_size
           | :empty_config
           | :parse_failed
 
@@ -124,7 +127,8 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
             ),
           committer: committer,
           commit_title: Map.get(toml, "commit_title", "Merge ${PR_REFS}"),
-          update_base_for_deletes: Map.get(toml, "update_base_for_deletes", false)
+          update_base_for_deletes: Map.get(toml, "update_base_for_deletes", false),
+          max_batch_size: Map.get(toml, "max_batch_size", nil)
         }
 
         case toml do
@@ -158,6 +162,10 @@ defmodule BorsNG.Worker.Batcher.BorsToml do
 
           %{commit_title: msg} when not is_binary(msg) and not is_nil(msg) ->
             {:error, :commit_title}
+
+          %{max_batch_size: max_batch_size}
+          when not is_nil(max_batch_size) and not is_integer(max_batch_size) ->
+            {:error, :max_batch_size}
 
           toml ->
             status =


### PR DESCRIPTION
This PR adds an optional `max_batch_size` setting to `bors.toml`.

With that setting, one can limit how many PR's can end up batched together.

Limiting the number of PR's can be useful to limit the effect of flaky tests, especially in a CI system that relies on caching (when more changes in a batch mean more caches getting busted, more tests being ran, and more flakes occurring), as well as serving as a workaround for times when GitHub experiences failures when pushing octomerges to the main branch (as it did for us for some 72 hours, this week).

Fixes #456