### PR TITLE
Set `Logger` level using `BORS_LOG_LEVEL` if provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,8 @@ Or you can do it manually:
         GITHUB_CLIENT_SECRET=<OAUTH_CLIENT_SECRET> \
         GITHUB_INTEGRATION_ID=<ISS> \
         GITHUB_INTEGRATION_PEM=`base64 -w0 priv.pem` \
-        GITHUB_WEBHOOK_SECRET=<SECRET2>
+        GITHUB_WEBHOOK_SECRET=<SECRET2> \
+        [BORS_LOG_LEVEL=<debug|info|warn|...>]
     $ git push heroku master
     $ heroku run POOL_SIZE=1 mix ecto.migrate
 
@@ -376,6 +377,9 @@ All the same recommendations apply, with some extra notes:
 - The `PORT` environment variable is set to `4000` by default.
 - `GITHUB_URL_ROOT_API` and `GITHUB_URL_ROOT_HTML` should allow you to connect bors-ng to an instance of GitHub Enterprise.
   Note: I've never actually used GitHub Enterprise, so I'm kinda guessing about what you'd need here.
+- `BORS_LOG_LEVEL` allows you to set the log level at runtime for bors-ng.
+  The allowed values are the usual Elixir `Logger` levels, e.g. `info`, `debug`, `warn`, etc.
+  Defaults to `info` if not set.
 
       docker create --name bors --restart=unless-stopped \
           -e PUBLIC_HOST=app.bors.tech \
@@ -389,6 +393,7 @@ All the same recommendations apply, with some extra notes:
           -e DATABASE_USE_SSL=false \
           -e DATABASE_AUTO_MIGRATE=true \
           -e COMMAND_TRIGGER=bors \
+          [-e BORS_LOG_LEVEL=<debug|info|warn|...>] \
           borsng/bors-ng
       docker start bors
 

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -1,6 +1,6 @@
 defmodule BorsNG.Application do
   @moduledoc """
-  The top-level OPT application for Bors-NG.
+  The top-level OTP application for Bors-NG.
   """
 
   use Application

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -19,9 +19,22 @@ defmodule BorsNG.Application do
     :persistent_term.get(:db_repo)
   end
 
+  defp get_log_level_from_env do
+    case System.get_env("BORS_LOG_LEVEL") do
+      nil -> nil
+      level_string -> String.to_existing_atom(level_string)
+    end
+  end
+
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do
+    log_level_from_env = get_log_level_from_env()
+
+    if not is_nil(log_level_from_env) do
+      Logger.configure(level: log_level_from_env)
+    end
+
     # Define workers and child supervisors to be supervised
     set_repo()
 

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -31,6 +31,9 @@ defmodule BorsNG.Application do
   def start(_type, _args) do
     log_level_from_env = get_log_level_from_env()
 
+    # Note: this only works if we do not use `:compile_time_purge_matching` in `config.exs`;
+    # otherwise all log level calls we want to ignore actually get purged entirely from the code.
+    # Ref: https://hexdocs.pm/logger/1.14.2/Logger.html#module-application-configuration
     if not is_nil(log_level_from_env) do
       Logger.configure(level: log_level_from_env)
     end


### PR DESCRIPTION
Sometimes when the Github API is on the fritz it can be useful to have debug-level logging.  Setting the log level in `config.exs` and rebuilding the container image is not ideal - having something more dynamic would be very nice to have.

This PR introduces the `BORS_LOG_LEVEL` environment variable which is converted to a `Logger` level atom using `String.to_existing_atom` when provided.  If `BORS_LOG_LEVEL` is unset, the `Logger` level will remain unchanged and is inherited from `config.exs` (i.e. `:info` for prod release).