### PR TITLE
Fix compilation warnings

### DIFF
--- a/lib/web/controllers/batch_controller.ex
+++ b/lib/web/controllers/batch_controller.ex
@@ -8,7 +8,6 @@ defmodule BorsNG.BatchController do
   use BorsNG.Web, :controller
 
   alias BorsNG.Database.Batch
-  alias BorsNG.Database.Context.Permission
   alias BorsNG.Database.Repo
   alias BorsNG.Database.Patch
   alias BorsNG.Database.Project
@@ -17,9 +16,6 @@ defmodule BorsNG.BatchController do
   def show(conn, %{"id" => id}) do
     batch = Repo.get(Batch, id)
     project = Repo.get(Project, batch.project_id)
-
-    allow_private_repos = Confex.fetch_env!(:bors, BorsNG)[:allow_private_repos]
-    admin? = conn.assigns.user.is_admin
 
     patches = Repo.all(Patch.all_for_batch(batch.id))
     statuses = Repo.all(Status.all_for_batch(batch.id))


### PR DESCRIPTION
Fixes the following warnings during compile the project:

```
warning: variable "admin?" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/web/controllers/batch_controller.ex:22: BorsNG.BatchController.show/2

warning: variable "allow_private_repos" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/web/controllers/batch_controller.ex:21: BorsNG.BatchController.show/2

warning: unused alias Permission
  lib/web/controllers/batch_controller.ex:11
```