### PR TITLE
Helm charts - Fix Bitnami dependency

### DIFF
--- a/deploy/charts/bors-ng/Chart.lock
+++ b/deploy/charts/bors-ng/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 10.3.14
-digest: sha256:14c30e99b228de7ddd2f70d9773a864d4a0ede4c846e6847cda345c234710e05
-generated: "2021-03-31T12:05:49.775412787+01:00"
+  repository: https://raw.githubusercontent.com/bitnami/charts/e0169502c14943782da50fc1977483fecd6912b5/bitnami
+  version: 11.6.0
+digest: sha256:02f0cd2712488ecd41dec1c427b4499bafa883fc26bb13cb470b52afbd2ecde3
+generated: "2023-03-06T12:05:10.725895-03:00"

--- a/deploy/charts/bors-ng/Chart.yaml
+++ b/deploy/charts/bors-ng/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 dependencies:
 - name: postgresql
   condition: postgresql.enabled
-  version: "10.3.14"
-  repository: https://charts.bitnami.com/bitnami
+  version: "11.6.0"
+  repository: https://raw.githubusercontent.com/bitnami/charts/e0169502c14943782da50fc1977483fecd6912b5/bitnami


### PR DESCRIPTION
There is an [open issue in Bitnami](https://github.com/bitnami/charts/issues/10539) that won't let us build the chart dependencies.

## Reproduction steps

1. Go to `deploy/charts/bors-ng` on the master branch of the `bors-ng` repo
2. Add the Bitnami repo
    - `helm repo add bitnami https://charts.bitnami.com/bitnami`
3. Try to build the dependencies
    - `helm dependency build`

You'll see an error like this:
<img width="671" alt="image" src="https://user-images.githubusercontent.com/26656167/223151896-3e9ddb69-cf29-4a98-8b53-7b80f777ec13.png">


## Test solution

Pre: Run `helm repo remove bitnami` to avoid name collision.

1. Go to `deploy/charts/bors-ng` on the `fix-helm-dependencies` branch of the fork repo.
2. Add the Bitnami repo
    - `helm repo add bitnami https://raw.githubusercontent.com/bitnami/charts/e0169502c14943782da50fc1977483fecd6912b5/bitnami`
3. Try to build the dependencies
    - `helm dependency build`

Update completes without errors
<img width="1053" alt="image" src="https://user-images.githubusercontent.com/26656167/223153287-1b7964b0-812d-48a2-84af-128d9ff1a61d.png">


I'm not a Helm expert so any feedback is welcome 🙂 .

