### PR TITLE
Use a sample user-agent for GitHub's OAuth2 flow

### DIFF
--- a/lib/github/oauth2/oauth2.ex
+++ b/lib/github/oauth2/oauth2.ex
@@ -57,7 +57,7 @@ defmodule BorsNG.GitHub.OAuth2 do
   @spec get_user!(t) :: BorsNG.GitHub.User.t()
   def get_user!(client) do
     client
-    |> OAuth2.Client.get!("/user")
+    |> OAuth2.Client.get!("/user", [{"user-agent", "bors-ng https://bors.tech"}])
     |> Map.fetch!(:body)
     |> BorsNG.GitHub.User.from_json!()
   end


### PR DESCRIPTION
Fixes #1668

GitHub recently began requiring a user agent for all API calls.  Most of the `bors-ng` API requests already provide such a user agent:

https://github.com/bors-ng/bors-ng/blob/cafd541242e4e83031d57f6e86ea74727656db5a/lib/github/github/server.ex#L967

… but the OAuth2 flow uses a separate http client which is missing the user agent, which this change fixes.

Unfortunately, there is no way to provide the headers via the configuration, as far as I know.  I originally tried to do something like:

```elixir
config :bors, BorsNG.GitHub.OAuth2,
  headers: …
```

… but that doesn't work because the `oauth2` package doesn't use the `headers` field of the `Client` struct.  It seems like the only way to customize the headers is via an explicit function argument.