### PR TITLE
Fix `get_statuses_!` to handle non-200 status codes

### DIFF
--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -551,7 +551,7 @@ defmodule BorsNG.GitHub.Server do
       |> Tesla.get!(url, query: params)
       |> case do
         %{body: raw, status: 200, headers: headers} -> {raw, headers}
-        _ -> {"[]", %{}}
+        _ -> {~s("statuses":[]), %{}}
       end
 
     statuses =


### PR DESCRIPTION
This is essentially the exact same fix as:

https://github.com/bors-ng/bors-ng/pull/1260

… except for `get_statuses_!` instead of `get_checks_!`

To provide some context (for both fixes), this is necessary in order to gracefully handle non-200 status codes.  Before this fix the non-200 code path would set `raw` to an empty list, and fail with:

```
** (ArgumentError) the Access calls for keywords expect the key to be an atom, got: "statuses"
    (elixir 1.13.4) lib/access.ex:310: Access.get/3
    (bors 0.1.0) lib/github/github/server.ex:599: BorsNG.GitHub.Server.get_statuses_!/3
    (bors 0.1.0) lib/github/github/server.ex:430: BorsNG.GitHub.Server.do_handle_call/3
    (bors 0.1.0) lib/github/github/server.ex:965: BorsNG.GitHub.Server.use_token!/3
    (stdlib 3.17.2.1) gen_server.erl:721: :gen_server.try_handle_call/4
    (stdlib 3.17.2.1) gen_server.erl:750: :gen_server.handle_msg/6
    (stdlib 3.17.2.1) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
```

… because it's trying to evaluate `[]["statuses"]`.  The fix is for `raw` to be an object of the correct shape so that the access succeeds.