### PR TITLE
Fix `sync_patch`'s use of `draft` field

### DIFF
--- a/lib/github/github/pr.ex
+++ b/lib/github/github/pr.ex
@@ -104,7 +104,7 @@ defmodule BorsNG.GitHub.Pr do
        },
        merged: not is_nil(merged_at),
        mergeable: mergeable,
-       draft: if(is_nil(pr[:draft]), do: false, else: pr.draft)
+       draft: if(is_nil(pr["draft"]), do: false, else: pr.draft)
      }}
   end
 
@@ -161,7 +161,7 @@ defmodule BorsNG.GitHub.Pr do
       },
       "merged_at" => merged_at,
       "mergeable" => nil,
-      "draft" => if(is_nil(pr[:draft]), do: false, else: pr.draft)
+      "draft" => if(is_nil(pr["draft"]), do: false, else: pr.draft)
     })
   end
 


### PR DESCRIPTION
The map returned by `Jason.decode` uses strings for keys and not atoms:

```elixir
>>> {:ok, json} = Jason.decode(~s({ "draft": true }))
{:ok, %{"draft" => true}}
>>> json
%{"draft" => true}
```

… which meant that `pr[:draft]` would always return `nil` and so `bors-ng` would never detect that a PR was in the draft state:

```elixir
>>> json[:draft]
nil
>>> json["draft"]
true
```

The fix is to check for `pr["draft"]`, which fixes the problem.

This wasn't caught by the tests because the tests create a map with atom keys, which didn't trigger this problem.