### PR TITLE
Enable production env VM settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,7 @@ RUN if [ -d .git ]; then \
 ####
 
 FROM debian:bullseye-slim
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8 LANGUAGE=C.UTF-8
 RUN apt-get update -q && apt-get --no-install-recommends install -y git-core libssl1.1 curl apt-utils ca-certificates
 
 ADD ./script/docker-entrypoint /usr/local/bin/bors-ng-entrypoint
@@ -50,7 +51,6 @@ RUN curl -Ls https://github.com/bors-ng/dockerize/releases/download/v0.7.12/dock
     tar xzv -C /usr/local/bin && \
     /app/bors/bin/bors describe
 
-ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 ENV PORT=4000
 ENV DATABASE_AUTO_MIGRATE=true
 ENV ALLOW_PRIVATE_REPOS=true

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -29,6 +29,8 @@ end
 environment :prod do
   set(include_erts: true)
   set(include_src: false)
+  # Custom vm.args
+  set(vm_args: "rel/prod.vm.args")
   set(cookie: :"nprGQlz(g].gBN%dbv?Wah!Mvz<;*FmALJ;z}B|RZ=`36uz:|Qc?P!>k?Q/o[hE~")
 end
 

--- a/rel/prod.vm.args
+++ b/rel/prod.vm.args
@@ -1,0 +1,3 @@
+# prod.vm.args
+-name bors@127.0.0.1
++sbwt none


### PR DESCRIPTION
Setup the project to allow `prod.vm.args` configs.

This is a starting point for eventual future improvements.