### PR TITLE
Do not update base branches if the branch could not be deleted

### DIFF
--- a/lib/worker/branch_deleter.ex
+++ b/lib/worker/branch_deleter.ex
@@ -97,13 +97,14 @@ defmodule BorsNG.Worker.BranchDeleter do
         end
 
       if delete do
+        GitHub.delete_branch!(conn, pr.head_ref)
+
+        # only update the base for deletes if the delete succeeded
         if update_base_for_deletes do
           GitHub.get_open_prs_with_base!(conn, pr.head_ref)
           |> Enum.map(&%{&1 | base_ref: pr.base_ref})
           |> Enum.map(&GitHub.update_pr_base!(conn, &1))
         end
-
-        GitHub.delete_branch!(conn, pr.head_ref)
       end
     end
   end


### PR DESCRIPTION
After someone made a PR from `master` to `random-branch`, bors tried to delete our master branch (which failed), but then re-targeted 200 of our open PRs against some random branch!

In this scenario, the branch deletion is forbidden by github; the intent in this change is to use this as a signal to not proceed with the re-targeting.

I'm working on the assumption that `.delete_branch!` throws an exception if it fails, but I'm not familiar with the language.

I understand that bors is EOL and so you might not want to spend time reviewing this.